### PR TITLE
Docs: No small caps in ipynb inline code

### DIFF
--- a/docs/_themes/sphinx_rtd_theme/static/css/ipynb.css
+++ b/docs/_themes/sphinx_rtd_theme/static/css/ipynb.css
@@ -69,7 +69,7 @@ margin: 2px;
 
 /* font-family: Courier; */
 font-weight: normal;
-font-variant: small-caps;
+/*font-variant: small-caps;*/
 color:#404040;
 overflow-x: auto;
 /* font-weight: bold; */

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,16 +1,16 @@
-MDTraj Examples
-====================
+OpenPathSampling Examples
+=========================
 
-This page provides a series of examples, tutorials and recipes to help you get
-started with ``openpathsampling``.
+This page provides a series of examples, tutorials and recipes to help you
+get started with ``openpathsampling``.
 
-Each subsection is a notebook.  To open these notebooks in a "live" IPython session
-and execute the documentation interactively, you need to download the repository
-and start the IPython notebook.
+Each subsection is a notebook.  To open these notebooks in a "live" IPython
+session and execute the documentation interactively, you need to download
+the repository and start the IPython notebook.
 
-If you installed `openpathsamplting` from source, you will need to navigate to
-:code:`path-to-mdtraj/examples`. The notebook files for these examples and the
-notebooks are available in the top level
+If you installed `openpathsamplting` from source, you will need to navigate
+to :code:`path-to-mdtraj/examples`. The notebook files for these examples
+and the notebooks are available in the top level
 
 .. code:: bash
 


### PR DESCRIPTION
Previous CSS used smallcaps for anything marked `code` in the Markdown cells of IPython notebooks. This made it (1) look different from the actual code cells; (2) look different from inline code in the rest of the sphinx docs; (2) look really ugly when there were many inline references to things from main code blocks (see the "Example trajectories for these ensembles" in http://openpathsampling.org/latest/examples/sliced.html for an example).

This fixes that. Also replaces one header MDTraj->OpenPathSampling.