### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
   - conda list -e
 
   # Run tests
-  #- source devtools/ci/nosetests.sh
-  #- source devtools/ci/ipythontests.sh
+  - source devtools/ci/nosetests.sh
+  - source devtools/ci/ipythontests.sh
 
   # Push to binstar anyway.
   - bash -x devtools/ci/after_sucess.sh

--- a/devtools/ci/ipythontests.sh
+++ b/devtools/ci/ipythontests.sh
@@ -1,11 +1,11 @@
 # Run ipython notebook tests
 
 cd examples/ipython
-python ipnbdoctest.py "alanine.ipynb"
-python ipnbdoctest.py "sliced_sequential_ensembles.ipynb"
-python ipnbdoctest.py "toy_dynamics_tis.ipynb"
-python ipnbdoctest.py "toy_storage.ipynb"
-python ipnbdoctest.py "langevin_integrator_check.ipynb"
-python ipnbdoctest.py "sliced_sequential_ensembles.ipynb"
-# python ipnbdoctest.py "visualization.ipynb"
+python ipnbdoctest.py "alanine.ipynb" || exit 1
+python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || exit 1
+python ipnbdoctest.py "toy_dynamics_tis.ipynb" || exit 1
+python ipnbdoctest.py "toy_storage.ipynb" || exit 1
+python ipnbdoctest.py "langevin_integrator_check.ipynb" || exit 1
+python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || exit 1
+# python ipnbdoctest.py "visualization.ipynb" || exit 1
 cd ../..

--- a/devtools/ci/nosetests.sh
+++ b/devtools/ci/nosetests.sh
@@ -2,5 +2,5 @@
 
 cd openpathsampling
 cd tests
-nosetests -v .
+nosetests -v . || exit 1
 cd ../..


### PR DESCRIPTION
**Problem**: The refactor of tests makes it so that Travis doesn't see that our tests fail, even when they do!

**Solution**: this PR

**Irony**: We currently have a failing test, so this PR should be merged if it FAILS Travis, not if it passes!

See, e.g., [build 351](https://travis-ci.org/choderalab/openpathsampling/builds/49457319#L1430) around line 1430. The `toy_dynamics_tis.ipynb` fails, but the build passes.