### PR TITLE
Should allow all tests in subscript to run

### DIFF
--- a/devtools/ci/ipythontests.sh
+++ b/devtools/ci/ipythontests.sh
@@ -1,11 +1,17 @@
 # Run ipython notebook tests
 
 cd examples/ipython
-python ipnbdoctest.py "alanine.ipynb" || exit 1
-python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || exit 1
-python ipnbdoctest.py "toy_dynamics_tis.ipynb" || exit 1
-python ipnbdoctest.py "toy_storage.ipynb" || exit 1
-python ipnbdoctest.py "langevin_integrator_check.ipynb" || exit 1
-python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || exit 1
-# python ipnbdoctest.py "visualization.ipynb" || exit 1
+testfail=0
+python ipnbdoctest.py "alanine.ipynb" || testfail=1
+python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || testfail=1
+python ipnbdoctest.py "toy_dynamics_tis.ipynb" || testfail=1
+python ipnbdoctest.py "toy_storage.ipynb" || testfail=1
+python ipnbdoctest.py "langevin_integrator_check.ipynb" || testfail=1
+python ipnbdoctest.py "sliced_sequential_ensembles.ipynb" || testfail=1
+# python ipnbdoctest.py "visualization.ipynb" || testfail=1
 cd ../..
+if [ testfail -eq 1 ]
+then
+    exit 1
+fi
+

--- a/devtools/ci/nosetests.sh
+++ b/devtools/ci/nosetests.sh
@@ -2,5 +2,10 @@
 
 cd openpathsampling
 cd tests
-nosetests -v . || exit 1
+testfail=0
+nosetests -v . || testfail=1
 cd ../..
+if [ testfail -eq 1 ]
+then
+    exit 1
+fi


### PR DESCRIPTION
I think this will make a small improvement as an addendum to #145 : previously the `ipythontests` stopped after the first failure. Better to run all the notebooks and see if anything else fails.