### PR TITLE
Important FIX: Wrong order or orderparameters

### DIFF
--- a/examples/ipython/storage_fastquery.ipynb
+++ b/examples/ipython/storage_fastquery.ipynb
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "storage = paths.storage.Storage('trajectory.nc')"
+    "storage = paths.storage.Storage('toy_tis.nc', mode='r')"
    ]
   },
   {
@@ -87,8 +87,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 169 ms, sys: 31.2 ms, total: 200 ms\n",
-      "Wall time: 197 ms\n"
+      "CPU times: user 497 ms, sys: 78.6 ms, total: 576 ms\n",
+      "Wall time: 573 ms\n"
      ]
     }
    ],
@@ -108,8 +108,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 639 ms, sys: 93.1 ms, total: 732 ms\n",
-      "Wall time: 690 ms\n"
+      "CPU times: user 1.18 s, sys: 95.9 ms, total: 1.27 s\n",
+      "Wall time: 1.25 s\n"
      ]
     }
    ],
@@ -136,8 +136,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 175 ms, sys: 35.9 ms, total: 211 ms\n",
-      "Wall time: 204 ms\n"
+      "CPU times: user 501 ms, sys: 75.8 ms, total: 576 ms\n",
+      "Wall time: 576 ms\n"
      ]
     }
    ],
@@ -157,8 +157,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 19.8 ms, sys: 4.06 ms, total: 23.8 ms\n",
-      "Wall time: 21.6 ms\n"
+      "CPU times: user 8.18 ms, sys: 2.56 ms, total: 10.7 ms\n",
+      "Wall time: 8.86 ms\n"
      ]
     }
    ],
@@ -185,14 +185,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-0.31502661109\n",
-      "-0.31502661109\n"
+      "55\n",
+      "55\n"
      ]
     }
    ],
    "source": [
-    "print result[10][10]\n",
-    "print result2[10][10]"
+    "print len(result[7])\n",
+    "print len(result2[7])"
    ]
   },
   {
@@ -206,8 +206,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "36\n",
-      "36\n"
+      "[-0.31501707434654236, -0.2983115017414093, -0.28195512294769287, -0.2657774090766907, -0.2497573047876358, -0.23495522141456604, -0.2195422351360321, -0.20341312885284424, -0.1872008889913559, -0.17233675718307495, -0.1587161123752594, -0.14402228593826294, -0.12843017280101776, -0.11265084892511368, -0.09750621765851974, -0.0836426168680191, -0.07128995656967163, -0.05995384603738785, -0.050597257912158966, -0.04296416416764259, -0.03672653064131737, -0.030981525778770447, -0.02509918063879013, -0.019207026809453964, -0.013423428870737553, -0.008521359413862228, -0.003990653902292252, 9.130006947088987e-05, 0.004414321389049292, 0.009233315475285053, 0.013210050761699677, 0.01668120175600052, 0.021027227863669395, 0.02659408375620842, 0.03332369029521942, 0.04136587306857109, 0.050867959856987, 0.06245562434196472, 0.07525467872619629, 0.08768647909164429, 0.10013026744127274, 0.11302581429481506, 0.12543348968029022, 0.13700954616069794, 0.15035530924797058, 0.16429296135902405, 0.17654328048229218, 0.18928666412830353, 0.20326165854930878, 0.21824216842651367, 0.23418055474758148, 0.25103849172592163, 0.26920178532600403, 0.2876758277416229, 0.3063449561595917]\n",
+      "[-0.31501707434654236, -0.2983115017414093, -0.28195512294769287, -0.2657774090766907, -0.2497573047876358, -0.23495522141456604, -0.2195422351360321, -0.20341312885284424, -0.1872008889913559, -0.17233675718307495, -0.1587161123752594, -0.14402228593826294, -0.12843017280101776, -0.11265084892511368, -0.09750621765851974, -0.0836426168680191, -0.07128995656967163, -0.05995384603738785, -0.050597257912158966, -0.04296416416764259, -0.03672653064131737, -0.030981525778770447, -0.02509918063879013, -0.019207026809453964, -0.013423428870737553, -0.008521359413862228, -0.003990653902292252, 9.130006947088987e-05, 0.004414321389049292, 0.009233315475285053, 0.013210050761699677, 0.01668120175600052, 0.021027227863669395, 0.02659408375620842, 0.03332369029521942, 0.04136587306857109, 0.050867959856987, 0.06245562434196472, 0.07525467872619629, 0.08768647909164429, 0.10013026744127274, 0.11302581429481506, 0.12543348968029022, 0.13700954616069794, 0.15035530924797058, 0.16429296135902405, 0.17654328048229218, 0.18928666412830353, 0.20326165854930878, 0.21824216842651367, 0.23418055474758148, 0.25103849172592163, 0.26920178532600403, 0.2876758277416229, 0.3063449561595917]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<openpathsampling.snapshot.Snapshot at 0x10ffd6550>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "traj = storage.trajectory[0]\n",
+    "print result[0]\n",
+    "print result2[0]\n",
+    "traj[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "101\n",
+      "101\n"
      ]
     }
    ],
@@ -225,27 +258,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 164 ms, sys: 32 ms, total: 196 ms\n",
-      "Wall time: 190 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "result_rep1 = storage.query.trajectory_orderparameter(op, replica=5)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 11,
    "metadata": {
     "collapsed": false
@@ -255,14 +267,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.8 ms, sys: 2.76 ms, total: 15.5 ms\n",
-      "Wall time: 14.4 ms\n"
+      "CPU times: user 507 ms, sys: 77.6 ms, total: 585 ms\n",
+      "Wall time: 581 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "result_rep2 = [op(sample.trajectory) for sset in storage.sampleset for sample in sset if sample.replica == 5]"
+    "result_rep1 = storage.query.trajectory_orderparameter(op, replica=5)"
    ]
   },
   {
@@ -276,21 +288,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-0.51075232029\n",
-      "-0.51075232029\n"
+      "CPU times: user 13.9 ms, sys: 4.29 ms, total: 18.2 ms\n",
+      "Wall time: 15.4 ms\n"
      ]
     }
    ],
    "source": [
-    "print result_rep1[10][10]\n",
-    "print result_rep2[10][10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "let also get a list of trajectory lengths"
+    "%%time\n",
+    "result_rep2 = [op(sample.trajectory) for sset in storage.sampleset for sample in sset if sample.replica == 5]"
    ]
   },
   {
@@ -304,14 +309,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 168 ms, sys: 34.4 ms, total: 202 ms\n",
-      "Wall time: 195 ms\n"
+      "-0.281955122948\n",
+      "-0.281955122948\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "result_len1 = storage.query.trajectory_length(replica=5)"
+    "print result[7][2]\n",
+    "print result2[7][2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "let also get a list of trajectory lengths"
    ]
   },
   {
@@ -325,14 +337,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.14 ms, sys: 1.36 ms, total: 6.5 ms\n",
-      "Wall time: 6.41 ms\n"
+      "CPU times: user 489 ms, sys: 75.6 ms, total: 565 ms\n",
+      "Wall time: 560 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "result_len2 = [len(sample.trajectory) for sset in storage.sampleset for sample in sset if sample.replica == 5 ]"
+    "result_len1 = storage.query.trajectory_length(replica=5)"
    ]
   },
   {
@@ -346,8 +358,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[18, 17, 16, 13, 13, 13, 13, 13, 11, 13, 13, 13, 13, 13, 15, 17, 17, 16, 17, 17, 15, 16, 16, 16, 16]\n",
-      "[18, 17, 16, 13, 13, 13, 13, 13, 11, 13, 13, 13, 13, 13, 15, 17, 17, 16, 17, 17, 15, 16, 16, 16, 16]\n"
+      "CPU times: user 873 µs, sys: 385 µs, total: 1.26 ms\n",
+      "Wall time: 1 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "result_len2 = [len(sample.trajectory) for sset in storage.sampleset for sample in sset if sample.replica == 5 ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 50, 50, 50, 50, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 65, 65, 65, 65, 65, 65]\n",
+      "[51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 49, 50, 50, 50, 50, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 65, 65, 65, 65, 65, 65]\n"
      ]
     }
    ],

--- a/openpathsampling/chainableobjectdict.py
+++ b/openpathsampling/chainableobjectdict.py
@@ -363,7 +363,10 @@ class CODStore(NestableObjectDict):
             loadable_keys = [x[1] for x in keys_sorted]
             loadable_idxs = [x[0] for x in keys_sorted]
             values_sorted = self.store.get_list_value(self.scope, loadable_keys)
-            return [values_sorted[idx] for idx in loadable_idxs]
+            ret = [0.0] * len(keys)
+            [ret.__setitem__(idx, values_sorted[pos])
+                    for pos, idx in enumerate(loadable_idxs)]
+            return ret
         else:
             return []
 

--- a/openpathsampling/storage/query_store.py
+++ b/openpathsampling/storage/query_store.py
@@ -7,10 +7,8 @@ class QueryStore():
     def trajectory_orderparameter(self, orderparameter, ensemble=None, replica=None, step=None):
         """
         Return list of orderparameters fast for specific sets of samples
-
         samples can be all samples found in specific or all sampleset and filter
         these by ensemble and/or replica.
-
         Parameters
         ----------
         orderparameter : paths.Orderparameter()
@@ -24,7 +22,6 @@ class QueryStore():
         step : int or None
             if not None only samples from the specific step are used.
             For `None` (default) all sampleset steps are considered.
-
         Returns
         -------
         list of list of float
@@ -65,10 +62,8 @@ class QueryStore():
     def trajectory_length(self, ensemble=None, replica=None, step=None):
         """
         Return list of trajectory lengths fast for specific sets of samples
-
         samples can be all samples found in specific or all sampleset and filter
         these by ensemble and/or replica.
-
         Parameters
         ----------
         ensemble : paths.Ensemble or None
@@ -80,7 +75,6 @@ class QueryStore():
         step : int or None
             if not None only samples from the specific step are used.
             For `None` (default) all sampleset steps are considered.
-
         Returns
         -------
         list of int

--- a/openpathsampling/storage/query_store.py
+++ b/openpathsampling/storage/query_store.py
@@ -36,7 +36,7 @@ class QueryStore():
 
         output = []
 
-        op_dict = orderparameter.storage_caches[storage]
+        op_dict = storage.cv.get_list_value(orderparameter, slice(None,None))
 
         for sset_id in range(len(storage.sampleset)):
             if step is not None and sset_id != step:


### PR DESCRIPTION
Due to the new netCDF sorted indices requirement I had this fixed, but apparently my test was not able to see, that the back-ordering after requesting from the netCDF file to the original index order was permuting in the wrong direction. This one fixes it.