### PR TITLE
Fix for SeqEns([A & B]) != SeqEns([B & A]) bug

### DIFF
--- a/examples/ipython/debug_logging.conf
+++ b/examples/ipython/debug_logging.conf
@@ -1,0 +1,45 @@
+# Default configuration file for OpenPathSampling loggers
+[loggers]
+keys=root,initialization
+
+[handlers]
+keys=stdout,initf,stdf
+
+[formatters]
+keys=standardFormatter,msgOnly
+
+[handler_stdout]
+class=StreamHandler
+level=NOTSET
+#formatter=standardFormatter
+formatter=msgOnly
+args=(sys.stdout,)
+
+[handler_initf]
+class=FileHandler
+level=INFO
+formatter=standardFormatter
+args=('initialization.log', 'w')
+
+[handler_stdf]
+class=FileHandler
+level=DEBUG
+formatter=standardFormatter
+args=('debug.log', 'w')
+
+[logger_root]
+level=INFO
+handlers=stdf
+
+[logger_initialization]
+level=INFO
+handlers=initf
+qualname=openpathsampling.initialization
+propagate=0
+
+[formatter_standardFormatter]
+format=(%(levelname)s)%(name)s: %(message)s
+
+[formatter_msgOnly]
+format=%(message)s
+


### PR DESCRIPTION
This fixes a weird bug where the order of a combination mattered when used with a SeqEns. Example of the problem, assuming you've set up a reasonable `bigvol` and length==1 `traj`:

```python
vol_ens = paths.AllInXEnsemble(bigvol)
len_ens = paths.LengthEnsemble(5)

combo1 = vol_ens & len_ens
combo2 = len_ens & vol_ens

seq1 = paths.SequentialEnsemble([combo1])
seq2 = paths.SequentialEnsemble([combo2])

print vol_ens.can_append(traj)
print len_ens.can_append(traj)
print combo1.can_append(traj)
print combo2.can_append(traj)
print seq1.can_append(traj)
print seq2.can_append(traj)
```

All of these should print `True`. However, the last one was printing `False`.

The bug appears to be that our short-circuit logic used `is True` instead of `== True`. In particular, the line in `EnsembleCombination.can_append` needed to read `if b == True` (even when `b` evaluated to `True`, it was following the `else` statement).

I'm not sure why this bug only manifested under the last set of circumstances, but this PR will fix it. Should be ready to merge as soon as tests pass.