### PR TITLE
[WIP] Better Tree Handling for PathMoveChanges

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -25,7 +25,7 @@ from pathmover import (
     ReplicaExchangeMover, ConditionalSequentialMover, EnsembleHopMover,
     PartialAcceptanceSequentialMover, ReplicaIDChangeMover, SequentialMover,
     ConditionalMover, FilterByReplica, RestrictToLastSampleMover,
-    CollapseMove, PathSimulatorMover, PathReversalSet,
+    PathSimulatorMover, PathReversalSet,
     NeighborEnsembleReplicaExchange
 )
 

--- a/openpathsampling/pathmovechange.py
+++ b/openpathsampling/pathmovechange.py
@@ -1,5 +1,3 @@
-from openpathsampling import ops_object
-
 __author__ = 'jan-hendrikprinz'
 
 import openpathsampling as paths
@@ -250,11 +248,6 @@ class PathMoveChange(object):
         >>> tree3 = [mover1, [mover2], [mover4, [mover5]]]
         >>> tree4 = []
 
-        Notes
-        -----
-        TODO: Add other types of nodes. e.g. explicit PathMoveChange,
-        Boolean for .accepted
-
         Parameters
         ----------
         item : PathMover, PathMoveChange, PathMoveTree
@@ -277,7 +270,8 @@ class PathMoveChange(object):
             return False
 
         else:
-            raise ValueError('Only PathMovers or PathMoveChanges can be tested.')
+            raise ValueError('Only PathMovers or PathMoveChanges or trees ' +
+                             'can be tested.')
 
     def __str__(self):
         return self.__class__.__name__[:-14] + '(' + str(self.idx.values()) + ')'

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -121,6 +121,9 @@ class PathMover(object):
         initialization_logging(logger=init_log, obj=self,
                                entries=['ensembles'])
 
+    def __repr__(self):
+        return self.__class__.__name__[:-5] + '(' + str(self.idx.values()) + ')'
+
     def __call__(self, sample_set):
         return sample_set
 

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -246,14 +246,8 @@ class PathMover(object):
         else:
             return self.name
 
-
-@ops_object
-class CollapseMove(PathMover):
-    def __init__(self, inner_mover):
-        self.inner_mover = inner_mover
-
-    def move(self, globalstate):
-        return self.inner_mover.move(globalstate).closed
+    def set_of_submovers(self):
+        return []
 
 @ops_object
 class ShootMover(PathMover):
@@ -262,7 +256,7 @@ class ShootMover(PathMover):
     a sample from a specified ensemble 
     '''
 
-    def __init__(self, selector, ensembles=None, replicas='all'):
+    def __init__(self, selector, ensembles=None):
         super(ShootMover, self).__init__(ensembles=ensembles)
         self.selector = selector
         if hasattr(PathMover, 'engine') and hasattr(PathMover.engine, 'max_length_stopper'):
@@ -448,6 +442,9 @@ class RandomChoiceMover(PathMover):
 
         initialization_logging(init_log, self,
                                entries=['movers', 'weights'])
+
+    def set_of_submovers(self):
+        return [ [mover] for mover in self.movers ]
 
     @keep_selected_samples
     def move(self, globalstate):
@@ -644,7 +641,7 @@ class RestrictToLastSampleMover(PathMover):
 @ops_object
 class ReplicaIDChangeMover(PathMover):
     """
-    Changes the replica ID for a path.
+    Changes the replica ID for a sample.
     """
     def __init__(self, replica_pairs, ensembles=None):
         self.replica_pairs = make_list_of_pairs(replica_pairs)
@@ -1299,19 +1296,6 @@ class MoveDetails(Details):
         self.results=None
         super(MoveDetails, self).__init__(**kwargs)
 
-    # @staticmethod
-    # def initialization(sample):
-    #     return MoveDetails.initialization_from_scratch(sample.trajectory,
-    #                                                    sample.ensemble)
-    #
-    # @staticmethod
-    # def initialization_from_scratch(trajectory, ensemble):
-    #     details = MoveDetails()
-    #     details.inputs = []
-    #     details.trials = trajectory
-    #     details.ensemble = ensemble # might go to Change and not Details
-    #     details.results = trajectory
-    #     return details
 
 @ops_object
 class SampleDetails(Details):


### PR DESCRIPTION
This will mostly cleanup the tree handling of PathMoveChanges. This includes

- [x] nested lists based tree description
- [x] implementation of `__contains__`
- [x] searching using subtrees
- [x] searching using wildcats in trees
- [x] searching using PathMover instances, PathMover class and PathMoveChange instances
- [ ] create list of all possible movetrees from a PathMover
- [ ] create list of all possible keys from a PathMover
- [ ] allow to check if a MovePathChange could have been generated by a PathMover

#### The new tree structure is as follows

1. A tree consists of nodes
2. Each node can have zero, one or more children
3. Each child is a node itself

#### The tree structure in openpathsampling is expressed as

1. The tree structure is given as a nested list.
2. The first element in the list is the head of the node
3. Element 2 to N are the children. This way we can access a child using __getitem__[#child] while [0] get the element of the node
4. Children are always wrapped in brackets
5. The head can be a PathMover instance or PathMoveChange instance or a wildcat

node = [head, [child1], [child2], ... ]

This means that the brackets naturally indicate going down `[` or going up `]` the tree

A tree can be a subtree if the subtree (always starting from the top)
fits on top of the tree to match. Here child nodes are ignored as long
as the mask of the subtree fits.

In searching wildcats are allowed. This works

1. slice(start, end) means an a number of arbitrary children between
    start and end-1
2. '*' means an arbitrary number of arbitrary children. Equal to slice(0, None)
3. None or '.' means ONE arbitrary child. Equal to slice(1,2)
4. '?' means ONE or NONE arbitrary child. Equal to slice(0,2)
5. '.', '?' and '*' on the head 

#### Examples

```
>>> tree1 = [mover1, [mover2]]
>>> tree2 = [mover1, [mover2], [mover3]]
>>> tree3 = [mover1, [mover2], [mover4, [mover5]]]
>>> tree4 = [] 
```

for wildcats we can write
```
>>> search = [mover1, [mover3]] # mover1 with first submover mover3.
>>> search = [mover1, '.', [mover3]] # mover1 with second submover mover3.
>>> search = [mover1, '*', [mover3]] # mover1 with submover mover3 at any point.
>>> search = [mover1, ['?', '.'], [mover3]] # mover1 with arbitrary first child hat must have one child (or more and second child of mover1 is mover3
```

Don't know how much we might use this, but it could be useful.