### PR TITLE
[WIP] add paired Snapshots and trajectory improvements

### DIFF
--- a/examples/ipython/alanine.ipynb
+++ b/examples/ipython/alanine.ipynb
@@ -112,7 +112,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [

--- a/openpathsampling/openmm_engine.py
+++ b/openpathsampling/openmm_engine.py
@@ -255,7 +255,7 @@ class OpenMMEngine(paths.DynamicsEngine):
 #                        self.simulation.context.getPeriodicBoxVectors(snapshot.box_vectors)
 
             if snapshot.momentum is not None:
-                if self._current_snapshot is None or snapshot.momentum is not self._current_snapshot.momentum or snapshot.reversed != self._current_snapshot.reversed:
+                if self._current_snapshot is None or snapshot.momentum is not self._current_snapshot.momentum or snapshot.is_reversed != self._current_snapshot.is_reversed:
                     # new snapshot has a different momenta (different coordinates and reverse setting)
                     # so update. Note snapshot.velocities is different from snapshot.momenta.velocities!!!
                     # The first includes the reversal setting in the snapshot the second does not.

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -394,7 +394,7 @@ class BackwardShootMover(ShootMover):
 
         # Run until one of the stoppers is triggered
         partial_trajectory = PathMover.engine.generate(
-            details.start_point.snapshot.reversed_copy(),
+            details.start_point.snapshot.reversed,
             running = [
                 paths.BackwardPrependedTrajectoryEnsemble(
                     ensemble,

--- a/openpathsampling/snapshot.py
+++ b/openpathsampling/snapshot.py
@@ -310,7 +310,8 @@ class Snapshot(object):
 
     def __init__(self, coordinates=None, velocities=None, box_vectors=None,
                  potential_energy=None, kinetic_energy=None, topology=None,
-                 configuration=None, momentum=None, is_reversed=False):
+                 configuration=None, momentum=None, is_reversed=False,
+                 reversed_copy=None):
         """
         Create a simulation snapshot. Initialization happens primarily in
         one of two ways:
@@ -390,10 +391,12 @@ class Snapshot(object):
             # something is wrong.
             if np.any(np.isnan(self.configuration.coordinates)):
                 raise ValueError("Some coordinates became 'nan'; simulation is unstable or buggy.")
-                
-        self._reversed = None
-        # this will always create the mirrored copy so we can save in pairs!
-        self.reversed
+
+        if reversed_copy is None:
+            # this will always create the mirrored copy so we can save in pairs!
+            self._reversed = Snapshot(configuration=self.configuration, momentum=self.momentum, is_reversed=not self.is_reversed, reversed_copy=self)
+        else:
+            self._reversed = reversed_copy
 
     @property
     @has('configuration')

--- a/openpathsampling/snapshot.py
+++ b/openpathsampling/snapshot.py
@@ -277,7 +277,7 @@ class Momentum(object):
         Momentum()
             the deep copy with reversed velocities.
         """
-        return self.copy(subset=subset, reversed=reversed)
+        return self.copy(subset=subset, reversed=True)
 
 
 
@@ -505,6 +505,8 @@ class Snapshot(object):
         Returns a shallow copy of the instance itself. The contained
         configuration and momenta are not copied.
 
+        This will also lead to a new reversed copy when using reversed!
+
         Returns
         -------
         Snapshot()
@@ -518,6 +520,8 @@ class Snapshot(object):
         Returns a shallow reversed copy of the instance itself. The
         contained configuration and momenta are not copied and the momenta
         are marked reversed.
+
+        This will also lead to a new (non-)reversed copy!
 
         Returns
         -------
@@ -563,5 +567,5 @@ class Snapshot(object):
         So far the potential and kinetic energies are copied and are thus false but still useful!?!
         """
 
-        this = Snapshot(configuration=self.configuration.copy(subset), momentum=self.momentum.copy(subset), reversed=self.is_reversed)
+        this = Snapshot(configuration=self.configuration.copy(subset), momentum=self.momentum.copy(subset), is_reversed=self.is_reversed)
         return this

--- a/openpathsampling/storage/snapshot_store.py
+++ b/openpathsampling/storage/snapshot_store.py
@@ -32,11 +32,14 @@ class SnapshotStore(ObjectStore):
         configuration_idx = self.configuration_idx(idx)
         momentum_idx = self.momentum_idx(idx)
         momentum_reversed = self.momentum_reversed(idx)
+        reversed_idx = self.reversed_idx(idx)
 
         snapshot.configuration = self.storage.configurations.load(configuration_idx)
         snapshot.momentum = self.storage.momentum.load(momentum_idx)
 
-        snapshot.reversed = momentum_reversed
+        snapshot._reversed = self.storage.snapshots.load()
+
+        snapshot.is_reversed = momentum_reversed
 
         return snapshot
 
@@ -85,7 +88,13 @@ class SnapshotStore(ObjectStore):
         else:
             self.save_variable('snapshot_momentum_idx', idx, -1)
 
-        self.save_variable('snapshot_momentum_reversed', idx, int(snapshot.reversed))
+        if snapshot._reversed is not None:
+            storage.snapshots.save(snapshot._reversed)
+            self.save_variable('snapshot_reversed_idx', idx, snapshot._reversed.idx[storage])
+        else:
+            self.save_variable('snapshot_reversed_idx', idx, -1)
+
+        self.save_variable('snapshot_momentum_reversed', idx, int(snapshot.is_reversed))
 
 
     def configuration_idx(self, idx):
@@ -120,6 +129,22 @@ class SnapshotStore(ObjectStore):
         '''
         return int(self.load_variable('snapshot_momentum_idx', idx))
 
+    def reversed_idx(self, idx):
+        '''
+        Load snapshot index for the reversed snapshot with ID 'idx'
+        from the storage
+
+        Parameters
+        ----------
+        idx : int
+            index of the snapshot
+
+        Returns
+        -------
+        int
+            reversed snapshot indices
+        '''
+        return int(self.load_variable('snapshot_reversed_idx', idx))
 
     def momentum_reversed(self, idx):
         '''
@@ -155,6 +180,11 @@ class SnapshotStore(ObjectStore):
                 )
 
         self.init_variable('snapshot_momentum_reversed', 'bool', self.db, chunksizes=(1, ))
+
+        self.init_variable('snapshot_reversed_idx', 'index', self.db,
+                description="snapshot[snapshot] is the idx of the reversed snapshot index (0..n_snapshot-1) 'frame' of snapshot 'snapshot'.",
+                chunksizes=(1, )
+                )
 
 #=============================================================================================
 # COLLECTIVE VARIABLE UTILITY FUNCTIONS

--- a/openpathsampling/storage/snapshot_store.py
+++ b/openpathsampling/storage/snapshot_store.py
@@ -27,19 +27,24 @@ class SnapshotStore(ObjectStore):
             the loaded snapshot instance
         '''
 
-        snapshot = Snapshot()
 
         configuration_idx = self.configuration_idx(idx)
         momentum_idx = self.momentum_idx(idx)
         momentum_reversed = self.momentum_reversed(idx)
         reversed_idx = self.reversed_idx(idx)
 
-        snapshot.configuration = self.storage.configurations.load(configuration_idx)
-        snapshot.momentum = self.storage.momentum.load(momentum_idx)
+        configuration = self.storage.configurations.load(configuration_idx)
+        momentum = self.storage.momentum.load(momentum_idx)
 
-        snapshot._reversed = self.storage.snapshots.load()
+        snapshot = Snapshot(configuration=configuration, momentum=momentum, is_reversed=momentum_reversed, reversed_copy=None)
+        snapshot_reversed = Snapshot(configuration=configuration, momentum=momentum, is_reversed=not momentum_reversed, reversed_copy=None)
 
-        snapshot.is_reversed = momentum_reversed
+        snapshot._reversed = snapshot_reversed
+        snapshot_reversed._reversed = snapshot
+
+        # fix caching!
+        snapshot_reversed.idx[self.storage] = reversed_idx
+        self.cache[reversed_idx] = snapshot_reversed
 
         return snapshot
 

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -90,7 +90,7 @@ class CalvinistDynamics(DynamicsEngine):
             self._current_snap = self.predestination[self.frame_index+1].copy()
             self.frame_index += 1
         else:
-            self._current_snap = self.predestination[self.frame_index-1].reversed_copy()
+            self._current_snap = self.predestination[self.frame_index-1].reversed
             self.frame_index -= 1
 
         return self._current_snap

--- a/openpathsampling/tests/teststorage.py
+++ b/openpathsampling/tests/teststorage.py
@@ -201,7 +201,13 @@ class testStorage(object):
             store.snapshots.load(0)
         )
 
-        assert_equal(store2.snapshots.count(), 1)
+        # check if the reversed copy also works
+        compare_snapshot(
+            store2.snapshots.load(1),
+            store.snapshots.load(1)
+        )
+
+        assert_equal(store2.snapshots.count(), 2)
         assert_equal(store2.trajectories.count(), 0)
 
         store.close()

--- a/openpathsampling/trajectory.py
+++ b/openpathsampling/trajectory.py
@@ -78,7 +78,7 @@ class Trajectory(list):
             the reversed trajectory
         '''
 
-        return Trajectory([snap.reversed_copy() for snap in reversed(self)])
+        return Trajectory([snap for snap in reversed(self)])
 
     def coordinates(self):
         """
@@ -252,8 +252,8 @@ class Trajectory(list):
             def next(self):
                 if self.idx > self.length:
                     self.idx -= 1
-                    obj = self.trajectory[self.idx]
-                    return obj
+                    snapshot = self.trajectory[self.idx]
+                    return snapshot.reversed
                 else:
                     raise StopIteration()
 


### PR DESCRIPTION
This will add that Snapshots are created in pairs. Each Snapshot and it's reversed one. 
This allows us to handle multiple reverses of snapshots to be identified as the same.

```
snapshot.reversed.reversed = snapshot
```

This requires to use
```
snapshot.reversed
```
to get the reversed snapshot. Not sure if we really want to use this. But that fixes the problem @dwhswenson had.

Last,
```
reversed(traj)
```
will return an iterator that runs in reversed order over reversed snapshots. So to get a reversed trajectory we can write
```
Trajectory(list(reversed(traj)))
```
or just
```
for reversed_snap in reversed(traj):
    # Do something
```