### PR TITLE
Fix ensemble testing

### DIFF
--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -1,6 +1,6 @@
 from nose.tools import assert_equal, assert_not_equal, raises
 from nose.plugins.skip import SkipTest
-from test_helpers import CallIdentity, prepend_exception_message
+from test_helpers import CallIdentity, prepend_exception_message, make_1d_traj
 
 import openpathsampling as paths
 from openpathsampling.ensemble import *
@@ -82,7 +82,7 @@ def setUp():
     global lower, upper, op, vol1, vol2, vol3, ttraj
     lower = 0.1
     upper = 0.5
-    op = CallIdentity()
+    op = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])
     vol1 = paths.LambdaVolume(op, lower, upper)
     vol2 = paths.LambdaVolume(op, -0.1, 0.7)
     vol3 = paths.LambdaVolume(op, 2.0, 2.5)
@@ -103,7 +103,8 @@ def setUp():
 
     # make the tests from lists into trajectories
     for test in ttraj.keys():
-        ttraj[test] = paths.Trajectory(ttraj[test])
+        ttraj[test] = make_1d_traj(coordinates=ttraj[test],
+                                   velocities=[1.0]*len(ttraj[test]))
 
 def in_out_parser(testname):
     allowed_parts = ['in', 'out']


### PR DESCRIPTION
We'd recently been getting occasional errors in `test_ensemble`. This PR fixes that.

In a test before this fix, I got errors 12/100 runs of `nosetests test_ensemble.py`. After this fix, 0/100.

The problem was in the way the test trajectories were built. For simplicity, early on I made test trajectories as lists of numbers instead of lists of snapshots. However, this created problems in certain parts of the code, because two "snapshots" in this fake trajectory list could have the same value, and the caching behavior assumes that snapshots never repeat in the trajectory.

The change makes the tests run a little slower (getting an order parameter from a snapshot is more expensive than reading a number from a list of them), but at least it's correct and tests pass consistently!

Anyway, this should fix the problem, and can be merged as soon as it passes tests.