### PR TITLE
[WIP] Fix Travis docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
   - conda list -e
 
   # Run tests
-  - source devtools/ci/nosetests.sh
-  - source devtools/ci/ipythontests.sh
+  #- source devtools/ci/nosetests.sh
+  #- source devtools/ci/ipythontests.sh
 
   # Push to binstar anyway.
   - bash -x devtools/ci/after_sucess.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ script:
   - conda list -e
 
   # Run tests
-  #- source devtools/ci/nosetests.sh
-  #- source devtools/ci/ipythontests.sh
+  - source devtools/ci/nosetests.sh
+  - source devtools/ci/ipythontests.sh
 
   # Push to binstar anyway.
   - bash -x devtools/ci/after_sucess.sh

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -1,22 +1,22 @@
 echo $TRAVIS_PULL_REQUEST $TRAVIS_BRANCH
 
-#if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-    #echo "This is a pull request. No deployment will be done."; exit 0
-#fi
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    echo "This is a pull request. No deployment will be done."; exit 0
+fi
 
-#if [[ "$TRAVIS_BRANCH" != "master" ]]; then
-    #echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
-#fi
+if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
+fi
 
-#if [[ "2.7" =~ "$python" ]]; then
-    #conda install --yes binstar jinja2
-	#conda convert -p all ~/miniconda/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda/conda-bld/
-    #binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda/conda-bld/*/openpathsampling-dev*.tar.bz2
-#fi
+if [[ "2.7" =~ "$python" ]]; then
+    conda install --yes binstar jinja2
+        conda convert -p all ~/miniconda/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda/conda-bld/
+    binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda/conda-bld/*/openpathsampling-dev*.tar.bz2
+fi
 
-#if [[ "$python" != "2.7" ]]; then
-    #echo "No deploy on PYTHON_VERSION=${python}"; exit 0
-#fi
+if [[ "$python" != "2.7" ]]; then
+    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
+fi
 
 
 # Create the docs and push them to S3
@@ -35,4 +35,4 @@ sudo apt-get install pandoc
 (cd docs && make html && cd -)
 ls -lt docs/_build
 pwd
-#python devtools/ci/push-docs-to-s3.py
+python devtools/ci/push-docs-to-s3.py

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -1,22 +1,22 @@
 echo $TRAVIS_PULL_REQUEST $TRAVIS_BRANCH
 
-if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-    echo "This is a pull request. No deployment will be done."; exit 0
-fi
+#if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    #echo "This is a pull request. No deployment will be done."; exit 0
+#fi
 
-if [[ "$TRAVIS_BRANCH" != "master" ]]; then
-    echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
-fi
+#if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    #echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
+#fi
 
-if [[ "2.7" =~ "$python" ]]; then
-    conda install --yes binstar jinja2
-	conda convert -p all ~/miniconda/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda/conda-bld/
-    binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda/conda-bld/*/openpathsampling-dev*.tar.bz2
-fi
+#if [[ "2.7" =~ "$python" ]]; then
+    #conda install --yes binstar jinja2
+	#conda convert -p all ~/miniconda/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda/conda-bld/
+    #binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda/conda-bld/*/openpathsampling-dev*.tar.bz2
+#fi
 
-if [[ "$python" != "2.7" ]]; then
-    echo "No deploy on PYTHON_VERSION=${python}"; exit 0
-fi
+#if [[ "$python" != "2.7" ]]; then
+    #echo "No deploy on PYTHON_VERSION=${python}"; exit 0
+#fi
 
 
 # Create the docs and push them to S3

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -35,4 +35,4 @@ sudo apt-get install pandoc
 (cd docs && make html && cd -)
 ls -lt docs/_build
 pwd
-python devtools/ci/push-docs-to-s3.py
+#python devtools/ci/push-docs-to-s3.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ sphinx
 ipython
 ipython-notebook
 jinja2
+netcdf4
 runipy
 openmm
 pytables


### PR DESCRIPTION
I'm sure @jhprinz also got an email from Travis on this, but the last two merges to master fail on Travis. See:

* https://travis-ci.org/choderalab/openpathsampling/builds/67765284
* https://travis-ci.org/choderalab/openpathsampling/builds/67765398

I'm trying to look into the problem: it only occurs while building the documentation, and it seems to be related to the conda environment that gets set up in the documentation build. At least, the complaint comes from a netcdf import statement, loading the hdf library, after you start running sphinx. Locally, the documentation builds without error for me.

The last successful build is here (for comparison purposes):

* https://travis-ci.org/choderalab/openpathsampling/builds/66374358

This started after the merge of PR #275, but re-checking the changes there, I don't see anything that looks like it could have caused this problem. My guess is that it is related to changes in the packages installed into the conda environment (perhaps the `hdf-1.8.14` to `hdf-1.8.15.1-1` change?)

I'll look around on this for a little while, but since I don't use conda, I may have to pass this off on someone who can properly reproduce the problem.