### PR TITLE
allow external defined classes to be stored

### DIFF
--- a/openpathsampling/storage/object_storage.py
+++ b/openpathsampling/storage/object_storage.py
@@ -123,7 +123,6 @@ class ObjectStore(object):
         self.has_uid = has_uid
         self.has_name = has_name
         self.json = json
-        self.simplifier = paths.storage.StorableObjectJSON(storage)
         self.identifier = self.db + '_uid'
         self._free = set()
         self._cached_all = False
@@ -196,6 +195,10 @@ class ObjectStore(object):
             self.load = types.MethodType(loadcache(_load), self)
 
         self._register_with_storage(nestable=nestable)
+
+    @property
+    def simplifier(self):
+        return self.storage.simplifier
 
     def __str__(self):
         return repr(self)

--- a/openpathsampling/storage/storage.py
+++ b/openpathsampling/storage/storage.py
@@ -108,6 +108,9 @@ class Storage(netcdf.Dataset):
     def objects(self):
         return self._objects
 
+    def update_storable_classes(self):
+        self.simplifier.update_class_list()
+
     def _setup_class(self):
         """
         Sets the basic properties for the storage
@@ -115,7 +118,7 @@ class Storage(netcdf.Dataset):
         self._storages = {}
         self._storages_base_cls = {}
         self.links = []
-        self.simplifier = paths.ObjectJSON()
+        self.simplifier = paths.storage.StorableObjectJSON(self)
         self.units = dict()
         # use no units
         self.dimension_units = {

--- a/openpathsampling/todict.py
+++ b/openpathsampling/todict.py
@@ -149,6 +149,10 @@ class ObjectJSON(object):
     def __init__(self, unit_system = None):
         self.excluded_keys = []
         self.unit_system = unit_system
+        self.class_list = dict()
+        self.update_class_list()
+
+    def update_class_list(self):
         self.class_list = paths.OPSNamed.objects()
 
     def simplify_object(self, obj, base_type = ''):


### PR DESCRIPTION
This adds a quick fix to update the internal list of storable objects. This will be the same in the new storage.

You can store locally created classes as well provided they are subclassed from `StorableObject` which is the case for all built-in storable OPS objects.

The list is created when a storage file is opened or created. If you define your class after opening a storage file you can call
```
storage.updated_storable_classes()
```
to update the list manually.

Note that classes are stored by class name and so no class names can be the same. Not sure what trouble this will cause. We sould add some testing if a user by accident creates classes that already exist.