### PR TITLE
EnsembleHopStrategy and ReplicaExchangeStrategy

### DIFF
--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -149,6 +149,10 @@ class MoveScheme(OPSNamed):
                             self.movers[group][idx] = mover
                     else:
                         self.movers[group].append(mover)
+        elif strategy.replace_group:
+            if strategy.from_group is not None:
+                self.movers.pop(strategy.from_group)
+            self.movers[group] = movers
         else:
             try:
                 self.movers[group].extend(movers)

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -358,15 +358,13 @@ class ReplicaExchangeStrategy(MoveStrategy):
             if n_ens == 2:
                 swap_list.append(sig[0])
             elif n_ens == 1:
-                other_sig = ((sig[1],),(sig[0],))
-                swap_list.append(sig[0])
-                signatures.remove(other_sig) 
-                #ValueError prevented by error check at beginning?
+                swap = (sig[0][0], sig[1][0])
+                if not (swap[1], swap[0]) in swap_list:
+                    swap_list.append(swap)
 
         swaps = [paths.ReplicaExchangeMover(swap[0], swap[1])
                  for swap in swap_list]
-        
-        pass
+        return swaps
 
 class EnsembleHopStrategy(ReplicaExchangeStrategy):
     """

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -92,6 +92,7 @@ class MoveStrategy(object):
         self.replace_signatures = None
         self.replace_movers = None
         self.set_replace(replace)
+        self.from_group = group
 
     @property
     def level(self):
@@ -112,11 +113,14 @@ class MoveStrategy(object):
         """Sets values for replace_signatures and replace_movers."""
         self.replace_signatures = False
         self.replace_movers = False
+        self.replace_group = False
         level_type = levels.level_type(self.level)
         if level_type == levels.SIGNATURE:
             self.replace_signatures = replace
         elif level_type == levels.MOVER:
             self.replace_movers = replace
+        elif level_type == levels.SUPERGROUP:
+            self.replace_group = replace
 
     def get_ensembles(self, scheme, ensembles):
         """

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -310,7 +310,16 @@ class EnsembleHopStrategy(MoveStrategy):
     """
     Converts ReplicaExchange to EnsembleHop.
     """
-    pass
+    def __init__(self, ensembles, group="repex", replace=True):
+        super(EnsembleHopStrategy, self).__init__(
+            ensembles=ensembles, group=group, replace=replace
+        )
+
+    def make_movers(self, scheme):
+        #TODO
+        # here we'll identify all the ensembles in self.group, and figure
+        # out what the hops would be, and make them
+        pass
 
 class PathReversalStrategy(MoveStrategy):
     """

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -330,9 +330,8 @@ class EnsembleHopStrategy(MoveStrategy):
         # make sense
         from_group = self.from_group
         if from_group is None:
-            self.replace = True
-        if self.replace:
             from_group = self.group
+        self.set_replace(self.replace)
         signatures = [m.ensemble_signature for m in scheme.movers[from_group]]
 
         # nested function used for error handling

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -366,6 +366,7 @@ class ReplicaExchangeStrategy(MoveStrategy):
                  for swap in swap_list]
         return swaps
 
+
 class EnsembleHopStrategy(ReplicaExchangeStrategy):
     """
     Converts ReplicaExchange to EnsembleHop.

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -339,8 +339,8 @@ class ReplicaExchangeStrategy(MoveStrategy):
                 )
             elif n_ens == 1: # already ensemble hop (ish)
                 assert(
-                    # TODO: check for detailed balance partner
-                    True or
+                    # TODO: add test for this
+                    (sig[1], sig[0]) in signatures or
                     sig_error(sig, errstr="No detailed balance partner. ")
                 )
             else:
@@ -356,9 +356,12 @@ class ReplicaExchangeStrategy(MoveStrategy):
         for sig in signatures:
             n_ens = len(sig[0])
             if n_ens == 2:
-                pass
+                swap_list.append(sig[0])
             elif n_ens == 1:
-                pass
+                other_sig = ((sig[1],),(sig[0],))
+                swap_list.append(sig[0])
+                signatures.remove(other_sig) 
+                #ValueError prevented by error check at beginning?
 
         swaps = [paths.ReplicaExchangeMover(swap[0], swap[1])
                  for swap in swap_list]

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -13,6 +13,7 @@ from openpathsampling.trajectory import Trajectory
 from openpathsampling.snapshot import Snapshot
 from openpathsampling.dynamics_engine import DynamicsEngine
 from openpathsampling.topology import Topology
+import openpathsampling as paths
 import numpy as np
 
 def make_1d_traj(coordinates, velocities=None, topology=None):
@@ -57,6 +58,10 @@ def assert_same_items(list_a, list_b):
         assert_in(elem_a, list_b)
 
 
+class MoverWithSignature(paths.PathMover):
+    def __init__(self, input_ensembles, output_ensembles):
+        self._in_ensembles = input_ensembles
+        self._out_ensembles = output_ensembles
 
 class CalvinistDynamics(DynamicsEngine):
     def __init__(self, predestination):

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -151,6 +151,7 @@ def true_func(value, *args, **kwargs):
 def setify_ensemble_signature(sig):
     return (set(sig[0]), set(sig[1]))
 
+
 def reorder_ensemble_signature(sig, match_with):
     setified = setify_ensemble_signature(sig)
     found_sigs = []

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -268,7 +268,12 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
     def test_replace_nofrom(self):
         # this is the default behavior
         scheme = DefaultScheme(self.network)
-        scheme.append(EnsembleHopStrategy())
+        scheme.movers ={}
+        scheme.append(EnsembleHopStrategy(replace=True, from_group=None))
+        scheme.move_decision_tree()
+        for m in scheme.movers['repex']:
+            print m.ensemble_signature
+        #assert_equal(len(scheme.movers['repex']), 8)
 
     def test_noreplace_from(self):
         # if replace is False and from_group is given, we end up with two

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -189,6 +189,32 @@ class testSelectedPairsRepExStrategy(MoveStrategyTestSetup):
         assert_equal(movers[2].ensemble_signature_set,
                      ({ens01, ens02}, {ens01, ens02}))
 
+class testReplicaExchangeStrategy(MoveStrategyTestSetup):
+    def test_make_movers(self):
+        strategy = ReplicaExchangeStrategy()
+        scheme = MoveScheme(self.network)
+        movers = strategy.make_movers(scheme)
+        assert_equal(len(movers), 4)
+
+    def test_swap_to_hop_to_swap(self):
+        scheme = DefaultScheme(self.network)
+        scheme.movers = {}
+        root = scheme.move_decision_tree()
+        assert_equal(len(scheme.movers['repex']), 6)
+        old_movers = scheme.movers['repex']
+        scheme.append(EnsembleHopStrategy())
+        root = scheme.move_decision_tree(rebuild=True)
+        assert_equal(len(scheme.movers['repex']), 12)
+        scheme.append(ReplicaExchangeStrategy())
+        root = scheme.move_decision_tree(rebuild=True)
+        assert_equal(len(scheme.movers['repex']), 6)
+        new_movers = scheme.movers['repex']
+        assert_not_equal(old_movers, new_movers)
+        old_sigs = [m.ensemble_signature_set for m in old_movers]
+        new_sigs = [m.ensemble_signature_set for m in new_movers]
+        for old in old_sigs:
+            assert_in(old, new_sigs)
+
 class testEnsembleHopStrategy(MoveStrategyTestSetup):
     def test_make_movers(self):
         strategy = EnsembleHopStrategy()

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -198,7 +198,7 @@ class testReplicaExchangeStrategy(MoveStrategyTestSetup):
 
     def test_swap_to_hop_to_swap(self):
         scheme = DefaultScheme(self.network)
-        scheme.movers = {}
+        scheme.movers = {} #LEGACY
         root = scheme.move_decision_tree()
         assert_equal(len(scheme.movers['repex']), 6)
         old_movers = scheme.movers['repex']
@@ -214,6 +214,19 @@ class testReplicaExchangeStrategy(MoveStrategyTestSetup):
         new_sigs = [m.ensemble_signature_set for m in new_movers]
         for old in old_sigs:
             assert_in(old, new_sigs)
+
+    @raises(RuntimeError)
+    def test_detailed_balance_partners(self):
+        scheme = DefaultScheme(self.network)
+        scheme.movers = {} #LEGACY
+        scheme.append(EnsembleHopStrategy())
+        root = scheme.move_decision_tree()
+        assert_equal(len(scheme.movers['repex']), 12)
+        scheme.movers['repex'].pop()
+        assert_equal(len(scheme.movers['repex']), 11)
+        strategy = ReplicaExchangeStrategy()
+        strategy.make_movers(scheme)
+
 
 class testEnsembleHopStrategy(MoveStrategyTestSetup):
     def test_make_movers(self):

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -1,5 +1,6 @@
 from nose.tools import (assert_equal, assert_not_equal, assert_items_equal,
-                        assert_almost_equal, raises, assert_in)
+                        assert_almost_equal, raises, assert_in,
+                        assert_not_in)
 from nose.plugins.skip import Skip, SkipTest
 from test_helpers import (
     true_func, assert_equal_array_array, make_1d_traj, MoverWithSignature,
@@ -294,11 +295,18 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
     def test_replace_from(self):
         # if replace is True and we have a different from_group, we should
         # remove the old from_group from existence
-        raise SkipTest
+        scheme = DefaultScheme(self.network)
+        scheme.movers ={}
+        scheme.append(EnsembleHopStrategy(replace=True, 
+                                          group='hop',
+                                          from_group='repex'))
+        scheme.move_decision_tree()
+        assert_equal(len(scheme.movers['hop']), 12)
+        assert_not_in("repex", scheme.movers.keys())
 
     def test_noreplace_nofrom(self):
-        # if replace==False and the from_group is not given, we have shoudl
-        # raise an error
+        # if replace==False and the from_group is not given, we should raise
+        # an error
         raise SkipTest
 
 

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -217,7 +217,6 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
         for mover in newmovers:
             assert_in(mover.ensemble_signature, mover_sigs)
 
-
     @raises(RuntimeError)
     def test_different_number_input_output_ensembles(self):
         ens0 = self.network.transition_ensembles[0]
@@ -265,6 +264,31 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
         scheme.movers['weird'] = [weird_mover]
         strategy = EnsembleHopStrategy(group='weird')
         strategy.make_movers(scheme)
+
+    def test_replace_nofrom(self):
+        # this is the default behavior
+        scheme = DefaultScheme(self.network)
+        scheme.append(EnsembleHopStrategy())
+
+    def test_noreplace_from(self):
+        # if replace is False and from_group is given, we end up with two
+        # groups: both the new and the old.
+        raise SkipTest
+
+    def test_noreplace_sameframe(self):
+        # if replace is False and we have the same from_group, we should
+        # raise an error
+        raise SkipTest
+
+    def test_replace_from(self):
+        # if replace is True and we have a different from_group, we should
+        # remove the old from_group from existence
+        raise SkipTest
+
+    def test_noreplace_nofrom(self):
+        # if replace==False and the from_group is not given, we have shoudl
+        # raise an error
+        raise SkipTest
 
 
 class testPathReversalStrategy(MoveStrategyTestSetup):

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -181,11 +181,34 @@ class testSelectedPairsRepExStrategy(MoveStrategyTestSetup):
         movers = strategy.make_movers(scheme)
         assert_equal(len(movers), 3)
         assert_equal(movers[0].ensemble_signature_set,
-                     ({ ens00, ens01 }, { ens00, ens01 }))
+                     ({ens00, ens01}, {ens00, ens01}))
         assert_equal(movers[1].ensemble_signature_set,
-                     ({ ens00, ens02 }, { ens00, ens02 }))
+                     ({ens00, ens02}, {ens00, ens02}))
         assert_equal(movers[2].ensemble_signature_set,
-                     ({ ens01, ens02 }, { ens01, ens02 }))
+                     ({ens01, ens02}, {ens01, ens02}))
+
+class testEnsembleHopStrategy(MoveStrategyTestSetup):
+    def test_make_movers(self):
+        strategy = EnsembleHopStrategy()
+        scheme = MoveScheme(self.network)
+        movers = strategy.make_movers(scheme)
+        # defaults to 4 repex movers, so
+        assert_equal(len(movers), 8)
+
+        # set up the swap pairs
+        swap_pairs = []
+        for trans in self.network.sampling_transitions:
+            swap_pairs.extend([[trans.ensembles[i], trans.ensembles[i+1]] 
+                               for i in range(len(trans.ensembles)-1)])
+        assert_equal(len(swap_pairs), 4)
+
+        # check that each swap pair has a hop
+        mover_sigs = [m.ensemble_signature for m in movers]
+        for pair in swap_pairs:
+            sig1 = ((pair[0],),(pair[1],))
+            sig2 = ((pair[1],),(pair[0],))
+            assert_in(sig1, mover_sigs)
+            assert_in(sig2, mover_sigs)
 
 
 class testPathReversalStrategy(MoveStrategyTestSetup):

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -271,14 +271,20 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
         scheme.movers ={}
         scheme.append(EnsembleHopStrategy(replace=True, from_group=None))
         scheme.move_decision_tree()
-        for m in scheme.movers['repex']:
-            print m.ensemble_signature
-        #assert_equal(len(scheme.movers['repex']), 8)
+        # 4 normal repex + 2 ms-outer repex = 6 repex * 2 hop/repex = 12
+        assert_equal(len(scheme.movers['repex']), 12)
 
     def test_noreplace_from(self):
         # if replace is False and from_group is given, we end up with two
         # groups: both the new and the old.
-        raise SkipTest
+        scheme = DefaultScheme(self.network)
+        scheme.movers ={}
+        scheme.append(EnsembleHopStrategy(replace=False, 
+                                          group='hop',
+                                          from_group='repex'))
+        scheme.move_decision_tree()
+        assert_equal(len(scheme.movers['repex']), 6)
+        assert_equal(len(scheme.movers['hop']), 12)
 
     def test_noreplace_sameframe(self):
         # if replace is False and we have the same from_group, we should

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -287,11 +287,6 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
         assert_equal(len(scheme.movers['repex']), 6)
         assert_equal(len(scheme.movers['hop']), 12)
 
-    def test_noreplace_sameframe(self):
-        # if replace is False and we have the same from_group, we should
-        # raise an error
-        raise SkipTest
-
     def test_replace_from(self):
         # if replace is True and we have a different from_group, we should
         # remove the old from_group from existence
@@ -305,9 +300,13 @@ class testEnsembleHopStrategy(MoveStrategyTestSetup):
         assert_not_in("repex", scheme.movers.keys())
 
     def test_noreplace_nofrom(self):
-        # if replace==False and the from_group is not given, we should raise
-        # an error
-        raise SkipTest
+        # if replace==False and the from_group is not given, we should
+        # act as mover replacement (but this is seriously a bad idea)
+        scheme = DefaultScheme(self.network)
+        scheme.movers ={}
+        scheme.append(EnsembleHopStrategy(replace=False, from_group=None))
+        scheme.move_decision_tree()
+        assert_equal(len(scheme.movers['repex']), 18)
 
 
 class testPathReversalStrategy(MoveStrategyTestSetup):


### PR DESCRIPTION
Adds the ability to switch between EnsembleHop and ReplicaExchange implementations of ensemble changing. This is a big step toward Single Replica TIS.

- [x] EnsembleHopStrategy
- [x] ReplicaExchangeStrategy
- [x] Check that we can switch back and forth

***

The approach here is to use the same "group" (repex) for both ensemble hop and replica exchange (although this can be customized in the strategy if the user really wants to). This is where some of the multiple-level stuff about move strategies (see #285). For example, a user can define a certain specific replica exchanges as being important using a `SelectedPairsRepExStrategy`, and then convert those to `EnsembleHop`s using the `EnsembleHopStrategy` -- and, of course, they can be switched back again by the `ReplicaExchangeStrategy`. It doesn't matter the order in which the user adds these strategies to the scheme doesn't matter; the `strategy.level` idea organizes them correctly.