### PR TITLE
visualize_frequency and timing hack

### DIFF
--- a/examples/ipython/mstis.ipynb
+++ b/examples/ipython/mstis.ipynb
@@ -649,7 +649,8 @@
     "background = ToyPlot()\n",
     "background.contour_range = np.arange(-1.5, 1.0, 0.1)\n",
     "background.add_pes(engine.pes)\n",
-    "mstis_calc.live_visualization.background = background.plot()"
+    "mstis_calc.live_visualization.background = background.plot()\n",
+    "#mstis_calc.visualize_frequency = 25 # speeds things up, but isn't as pretty"
    ]
   },
   {
@@ -687,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -351,7 +351,7 @@ class PathSampling(PathSimulator):
         initialization_logging(init_log, self, 
                                ['move_scheme', 'globalstate'])
         self.live_visualization = None
-        self.visualization_frequency = 1
+        self.visualize_frequency = 1
         self._mover = paths.PathSimulatorMover(self.move_scheme, self)
 
     def run_until(self, nsteps):
@@ -378,25 +378,27 @@ class PathSampling(PathSimulator):
             self.step += 1
             logger.info("Beginning MC cycle " + str(self.step))
             refresh=True
-            if self.live_visualization is not None and mcstep is not None:
-                # do we visualize at all?
-                if self.step % self.visualization_frequency == 0:
-                    # do we visualize this step?
+            if self.step % self.visualize_frequency == 0:
+                # do we visualize this step?
+                if self.live_visualization is not None and mcstep is not None:
+                    # do we visualize at all?
                     self.live_visualization.draw_ipynb(mcstep)
                     refresh=False
 
-            paths.tools.refresh_output(
-                "Working on Monte Carlo cycle step " + str(self.step) + ".\n",
-                refresh=refresh
-            )
+                paths.tools.refresh_output(
+                    "Working on Monte Carlo cycle number " + str(self.step)
+                    + ".\n", 
+                    refresh=refresh
+                )
 
             time_start = time.time() 
             movepath = self._mover.move(self.globalstate, step=self.step)
             samples = movepath.results
             new_sampleset = self.globalstate.apply_samples(samples)
             time_elapsed = time.time() - time_start
-            # TODO: we can save this with the MC steps for timing?
 
+            # TODO: we can save this with the MC steps for timing? The bit
+            # below works, but is only a temporary hack
             setattr(movepath.details, "timing", time_elapsed)
 
             mcstep = MCStep(

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -3,6 +3,8 @@ import openpathsampling as paths
 import openpathsampling.tools
 from openpathsampling.pathmover import SubPathMover
 
+import time
+
 import logging
 from ops_logging import initialization_logging
 logger = logging.getLogger(__name__)
@@ -349,6 +351,7 @@ class PathSampling(PathSimulator):
         initialization_logging(init_log, self, 
                                ['move_scheme', 'globalstate'])
         self.live_visualization = None
+        self.visualization_frequency = 1
         self._mover = paths.PathSimulatorMover(self.move_scheme, self)
 
     def run_until(self, nsteps):
@@ -376,17 +379,25 @@ class PathSampling(PathSimulator):
             logger.info("Beginning MC cycle " + str(self.step))
             refresh=True
             if self.live_visualization is not None and mcstep is not None:
-                self.live_visualization.draw_ipynb(mcstep)
-                refresh=False
+                # do we visualize at all?
+                if self.step % self.visualization_frequency == 0:
+                    # do we visualize this step?
+                    self.live_visualization.draw_ipynb(mcstep)
+                    refresh=False
 
             paths.tools.refresh_output(
                 "Working on Monte Carlo cycle step " + str(self.step) + ".\n",
                 refresh=refresh
             )
 
+            time_start = time.time() 
             movepath = self._mover.move(self.globalstate, step=self.step)
             samples = movepath.results
             new_sampleset = self.globalstate.apply_samples(samples)
+            time_elapsed = time.time() - time_start
+            # TODO: we can save this with the MC steps for timing?
+
+            setattr(movepath.details, "timing", time_elapsed)
 
             mcstep = MCStep(
                 simulation=self,
@@ -412,6 +423,10 @@ class PathSampling(PathSimulator):
             self.globalstate = new_sampleset
 
         self.sync_storage()
+
+        if self.live_visualization is not None and mcstep is not None:
+            self.live_visualization.draw_ipynb(mcstep)
         paths.tools.refresh_output(
-            "DONE! Completed " + str(self.step) + " Monte Carlo cycles.\n"
+            "DONE! Completed " + str(self.step) + " Monte Carlo cycles.\n",
+            refresh=False
         )


### PR DESCRIPTION
Resolves #339 

Now you can set the visualization frequency using, for example:

```python
mstis_calc.visualize_frequency = 50 # redraw every 50 steps
```

This also contain a little hack related to an email @bolhuis sent me earlier, asking about computational cost for different kinds of moves. It turns out, it is easier to get the actual time than the number of MD steps used (still desired; see #292). However, this temporary hack lets you get timings from `step.change.details.timing` (for any step except the first, which doesn't have a mover associated with it anyway).

So,

```python
import numpy as np
repex_timings = np.array(
    [s.change.details.timing 
     for s in storage.steps 
     if s.change.canonical.mover in scheme.movers['repex']]
)
print repex_timings.mean(), repex_timings.std()
```

***Aside***: when I tried this out, I noticed that I had a few *very slow* repex moves (half a second?) even though most were less than 0.1 seconds. Might be worth looking into what's going on there. Could just be long trajectories, but I don't know. (RepEx in OPS has to loop all frames in each trajectory to check acceptance, because we don't take short-cuts based on assuming our ensembles are TIS ensembles).

Same works for other cases where mover group definition is the same as canonical mover definition (minus, path reversal). However, for some reason `OneWayShooting` isn't canonical (I think we decided this, but I'd still suggest changing it). You can still extract those timings using something like:

```python
shooting_timings = []
for step in storage.steps:
    for shooter in scheme.movers['shooting']:
        if shooter in step.change:
            shooting_timings.append(step.change.details.timing)
shooting_timings = np.array(shooting_timings)
print shooting_timings.mean(), shooting_timings.std()
```

Note that in the toy models, nearly the entire cost is in the overhead. So you'll find that shooting moves cost the same as replica exchange, because both loop over each frame of the trajectory once. Saving metadata about the trajectory and the ensembles could speed this up in the specific case of TIS, but so far we've focused on keeping everything as generic as possible. The overhead should be roughly constant with system size, so even a half-second per replica exchange isn't much when running dynamics in large systems.