### PR TITLE
Single Replica Minus Mover

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -24,18 +24,18 @@ from collectivevariable import CV_Function, CV_MD_Function, CV_Featurizer, \
     CV_Volume, CollectiveVariable
 
 from pathmover import (
-    BackwardShootMover, MinusMover, RandomChoiceMover, ForwardShootMover,
-    PathMover, PathMoverFactory, PathReversalMover,
-    ReplicaExchangeMover, ConditionalSequentialMover, EnsembleHopMover,
-    PartialAcceptanceSequentialMover, ReplicaIDChangeMover, SequentialMover,
-    ConditionalMover, RestrictToLastSampleMover, PathSimulatorMover,
-    PathReversalSet, NeighborEnsembleReplicaExchange, SampleMover,
-    StateSwapMover, FinalSubtrajectorySelectMover, EngineMover,
+    RandomChoiceMover, PathMover, ConditionalSequentialMover,
+    PartialAcceptanceSequentialMover, BackwardShootMover, ForwardShootMover,
+    ShootMover, BackwardExtendMover, ForwardExtendMover, MinusMover,
+    SingleReplicaMinusMover, PathMoverFactory, PathReversalMover,
+    ReplicaExchangeMover, EnsembleHopMover, ReplicaIDChangeMover,
+    SequentialMover, ConditionalMover, RestrictToLastSampleMover,
+    PathSimulatorMover, PathReversalSet, NeighborEnsembleReplicaExchange,
+    SampleMover, StateSwapMover, FinalSubtrajectorySelectMover, EngineMover,
     SwappingMover, FirstSubtrajectorySelectMover, MultipleSetMinusMover,
-    OneWayShootingMover, RandomSubtrajectorySelectMover, ShootMover,
-    SubPathMover, BackwardExtendMover, EnsembleFilterMover,
-    ForwardExtendMover, SelectionMover, FirstAllowedMover, LastAllowedMover,
-    OneWayExtendMover
+    OneWayShootingMover, RandomSubtrajectorySelectMover, SubPathMover,
+    EnsembleFilterMover, SelectionMover, FirstAllowedMover,
+    LastAllowedMover, OneWayExtendMover
 )
 
 from shooting import ShootingPoint, ShootingPointSelector, UniformSelector, \

--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -459,7 +459,22 @@ class MinusMoveStrategy(MoveStrategy):
         return movers
 
 class SingleReplicaMinusMoveStrategy(MinusMoveStrategy):
-    pass
+    """
+    Takes a given scheme and makes a single-replica minus mover.
+    """
+    def make_movers(self, scheme):
+        network = scheme.network
+        ensemble_list = self.get_ensembles(scheme, self.ensembles)
+        ensembles = reduce(list.__add__, map(lambda x: list(x), ensemble_list))
+        movers = []
+        for ens in ensembles:
+            innermosts = [t.ensembles[0] 
+                          for t in network.special_ensembles['minus'][ens]]
+            movers.append(paths.SingleReplicaMinusMover(
+                minus_ensemble=ens, 
+                innermost_ensembles=innermosts
+            ))
+        return movers
 
 
 class OrganizeByMoveGroupStrategy(MoveStrategy):

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -1993,33 +1993,32 @@ class SingleReplicaMinusMover(SubPathMover):
 
         segment = minus_ensemble._segment_ensemble
 
-        hop_to_segment = RandomAllowedChoiceMover([
+        hop_innermost_to_segment = RandomAllowedChoiceMover([
             EnsembleHopMover(innermost, segment, bias=bias)
             for innermost in innermost_ensembles
         ])
 
+        hop_segment_to_innermost = RandomChoiceMover([
+            EnsembleHopMover(segment, innermost, bias=bias)
+            for innermost in innermost_ensembles
+        ])
+
         forward_minus = ConditionalSequentialMover([
-            hop_to_segment,
+            hop_innermost_to_segment,
             ForwardExtendMover(segment, minus_ensemble),
             FinalSubtrajectorySelectMover(minus_ensemble, segment),
-            RandomChoiceMover([
-                EnsembleHopMover(minus_ensemble, innermost, bias=bias)
-                for innermost in innermost_ensembles
-            ])
+            hop_segment_to_innermost
         ])
 
         backward_minus = ConditionalSequentialMover([
-            hop_to_segment,
+            hop_innermost_to_segment,
             BackwardExtendMover(segment, minus_ensemble),
             FirstSubtrajectorySelectMover(minus_ensemble, segment),
-            RandomChoiceMover([
-                EnsembleHopMover(minus_ensemble, innermost, bias=bias)
-                for innermost in innermost_ensembles
-            ])
+            hop_segment_to_innermost
         ])
 
-        mover = EnsembleFilterMover(RandomChoiceMover(backward_minus, 
-                                                      forward_minus),
+        mover = EnsembleFilterMover(RandomChoiceMover([backward_minus, 
+                                                       forward_minus]),
                                     ensembles=innermost_ensembles)
 
         super(SingleReplicaMinusMover, self).__init__(mover)

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -1924,7 +1924,7 @@ class MinusMover(SubPathMover):
 
         super(MinusMover, self).__init__(mover)
 
-class SingleReplicaMinusMover(SubPathMover):
+class SingleReplicaMinusMover(MinusMover):
     """
     Minus mover for single replica TIS.
 
@@ -1932,9 +1932,6 @@ class SingleReplicaMinusMover(SubPathMover):
     minus interface. Instead, it just puts the newly generated segment into
     the innermost ensemble.
     """
-    _is_canonical = True
-
-
     def __init__(self, minus_ensemble, innermost_ensembles, bias=None):
         try:
             innermost_ensembles = list(innermost_ensembles)
@@ -1980,7 +1977,8 @@ class SingleReplicaMinusMover(SubPathMover):
                                                        forward_minus]),
                                     ensembles=innermost_ensembles)
 
-        super(SingleReplicaMinusMover, self).__init__(mover)
+        # we skip MinusMover's init and go to the grandparent
+        super(MinusMover, self).__init__(mover)
 
 
 

--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -1982,14 +1982,26 @@ class MinusMover(SubPathMover):
 class SingleReplicaMinusMover(SubPathMover):
     """
     Minus mover for single replica TIS.
+
+    In SRTIS, the minus mover doesn't actually keep an active sample in the
+    minus interface. Instead, it just puts the newly generated segment into
+    the innermost ensemble.
     """
     _is_canonical = True
+
 
     def __init__(self, minus_ensemble, innermost_ensembles, bias=None):
         try:
             innermost_ensembles = list(innermost_ensembles)
         except TypeError:
             innermost_ensembles = [innermost_ensembles]
+
+        # TODO: Until we have automated detailed balance calculations, I
+        # think this will only be valid in the case of only one innermost
+        # ensemble.  But I think you only want to use it in the case of only
+        # one innermost ensemble anyway. The following warns us:
+        if len(innermost_ensembles) > 1:
+            logger.warning("Probably shouldn't use SingleReplicaMinusMover with MISTIS")
 
         segment = minus_ensemble._segment_ensemble
 
@@ -1998,6 +2010,8 @@ class SingleReplicaMinusMover(SubPathMover):
             for innermost in innermost_ensembles
         ])
 
+        # TODO: again, works for single interface set, but there has to be a
+        # smarter way to do this in the MISTIS case
         hop_segment_to_innermost = RandomChoiceMover([
             EnsembleHopMover(segment, innermost, bias=bias)
             for innermost in innermost_ensembles

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -431,6 +431,22 @@ class testMinusMoveStrategy(MoveStrategyTestSetup):
             )
 
 
+class testSingleReplicaMinusMoveStrategy(MoveStrategyTestSetup):
+    def test_make_movers(self):
+        strategy = SingleReplicaMinusMoveStrategy()
+        scheme = MoveScheme(self.network)
+        movers = strategy.make_movers(scheme)
+        assert_equal(len(movers), 2)
+
+        minuses = self.network.special_ensembles['minus']
+        ens_minusA = minuses.keys()[0]
+        ens_innerA = [t.ensembles[0] for t in minuses[ens_minusA]]
+        sig_A = set([ens_minusA] + ens_innerA)
+        ens_minusB = minuses.keys()[1]
+        ens_innerB = [t.ensembles[0] for t in minuses[ens_minusB]]
+        sig_B = set([ens_minusB] + ens_innerB)
+        all_ens_sigs = [m.ensemble_signature_set for m in movers]
+
 
 class testOrganizeByMoveGroupStrategy(MoveStrategyTestSetup):
     def scheme_setup_shooting_repex(self):

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -1114,7 +1114,7 @@ class testSingleReplicaMinusMover(object):
             # goes to other state:
             1.16, 1.26, 1.16, -0.16, 1.16, 1.26, 1.16
         ])
-        SampleGeneratingMover.engine = self.dyn
+        SampleMover.engine = self.dyn
         self.dyn.initialized = True
         self.innermost = paths.TISEnsemble(volA, volB, volX)
         self.minus = paths.MinusInterfaceEnsemble(volA, volX)

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -1138,9 +1138,6 @@ class testSingleReplicaMinusMover(object):
     def test_is_ensemble_change_mover(self):
         assert_equal(self.mover.is_ensemble_change_mover, True)
 
-    def test_is_canonical(self):
-        assert_equal(self.mover.is_canonical, True)
-
     def test_successful_move(self):
         init_innermost = make_1d_traj(self.list_innermost, [1.0]*5)
         init_sample = Sample(

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -1157,26 +1157,26 @@ class testSingleReplicaMinusMover(object):
         # assert_equal(self.minus(make_1d_traj(extend_backward)), True)
 
         seg_dir = {}
-        for i in range(100):
+        for i in range(10):
             change = self.mover.move(gs)
             samples = change.results
             sub_samples = change.subchange.subchange.results
-            # assert_equal(len(samples), 2)
-            # assert_equal(len(sub_samples), 4)
-            # s_inner = [s for s in sub_samples if s.ensemble==self.innermost]
-            # s_minus = [s for s in sub_samples if s.ensemble==self.minus]
-            # s_sub = [s for s in sub_samples if s.ensemble==self.minus._segment_ensemble]
-            #assert_equal(len(s_inner), 1)
-            #assert_equal(len(s_minus), 1)
-            #assert_equal(len(s_sub), 2)
+            assert_equal(len(samples), 1)
+            assert_equal(len(sub_samples), 4)
+            s_inner = [s for s in sub_samples if s.ensemble==self.innermost]
+            s_minus = [s for s in sub_samples if s.ensemble==self.minus]
+            s_seg = [s for s in sub_samples if s.ensemble==self.minus._segment_ensemble]
+            assert_equal(len(s_inner), 1)
+            assert_equal(len(s_minus), 1)
+            assert_equal(len(s_seg), 2)
 
-            #for c in change:
-            #    assert_equal(c.accepted, True)
+            for c in change:
+               assert_equal(c.accepted, True)
 
             assert_equal(change.canonical.mover, self.mover)
 
-            # key = ""
-            # s_inner0_xvals = [s.coordinates[0,0] for s in s_inner[0].trajectory]
+            key = ""
+            s_inner0_xvals = [s.coordinates[0,0] for s in s_inner[0].trajectory]
             # if items_equal(s_inner0_xvals, self.first_segment):
                 # key += "1"
             # elif items_equal(s_inner0_xvals, self.second_segment):
@@ -1185,7 +1185,7 @@ class testSingleReplicaMinusMover(object):
                 # print "s_inner0_xvals:", s_inner0_xvals
                 # raise RuntimeError("Chosen segment neither first nor last!")
 
-            # # final sample s_minus is accepted
+            # final sample s_minus is accepted
             # s_minus_xvals = [s.coordinates[0,0] for s in s_minus[-1].trajectory]
             # if items_equal(s_minus_xvals, extend_forward):
                 # key += "f"

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -1211,4 +1211,19 @@ class testSingleReplicaMinusMover(object):
                 seg_dir[key] = 1
         assert_equal(len(seg_dir.keys()), 2)
 
+    def test_first_hop_fails(self):
+        crossing_traj = make_1d_traj([-0.11, 0.11, 0.31, 1.01], [1.0]*4)
+        crossing_samp = Sample(replica=0, trajectory=crossing_traj,
+                               ensemble=self.innermost)
+        gs = SampleSet([crossing_samp])
+        gs.sanity_check()
 
+        change = self.mover.move(gs)
+        assert_equal(len(change.results), 0)
+        sub_trials = change.subchange.subchange.trials
+        assert_equal(len(sub_trials), 1)
+        assert_equal(sub_trials[0].trajectory, crossing_traj)
+        assert_equal(sub_trials[0].ensemble, self.minus._segment_ensemble)
+
+    def test_extension_fails(self):
+        raise SkipTest


### PR DESCRIPTION
The SRMinusMover is a little different from the standard minus mover: instead of keeping an active minus ensemble, the minus ensemble is only used as an intermediate. 

As before, we define the innermost ensemble, the minus ensemble, and the "segment" ensemble, which is like the innermost except it only allows A->A paths.

The basic process for the single replica minus is like this:

1. Hop innermost->segment
2. Extend segment->minus
3. Select subtrajectory in segment
4. Hop segment->innermost

In practice, this is split into a forward minus and a backward minus: forward minus extends forward and selects final subtraj; backward minus extends backward and selects first subtraj. The total `SingleReplicaMinusMover` has a 50/50 chance of selecting its forward or its backward submover.

So the normal `MinusMover` is a replica exchange between the `minus_ensemble` and one of the `innermost_ensemble`s. On the other hand,the single replica minus mover is a move from `innermost_ensemble` to (hypothetically another) `innermost_ensemble`.

As mentioned in #331, this approach is really only useful for single innermost interfaces. In fact, the code as implemented will only be correct in that case (and raises a warning if you aren't).

- [x] SingleReplicaMinusMover
- [x] Tests for SRMinusMover
- [x] SingleReplicaMinusMoveStrategy
- [x] Tests for SingleReplicaMinusMoverStrategy
