### PR TITLE
Update miniconda install path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 install:
   - deactivate
-  # Sets up a MINIConda enviroment in the name of the selected python verson
+  # Sets up a MINIConda enviroment in the name of the selected python version
   - source devtools/ci/install.sh
   # Don't know what this is meant for
   - export PYTHONUNBUFFERED=true
@@ -21,7 +21,7 @@ script:
   - conda install --yes conda-build jinja2
   - conda build devtools/conda-recipe
   - source activate $python
-  - conda install --yes $HOME/miniconda/conda-bld/linux-64/openpathsampling-*
+  - conda install --yes $HOME/miniconda2/conda-bld/linux-64/openpathsampling-*
   - conda list -e
 
   # Run tests

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -10,8 +10,8 @@ fi
 
 if [[ "2.7" =~ "$python" ]]; then
     conda install --yes binstar jinja2
-        conda convert -p all ~/miniconda/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda/conda-bld/
-    binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda/conda-bld/*/openpathsampling-dev*.tar.bz2
+        conda convert -p all ~/miniconda2/conda-bld/linux-64/openpathsampling-dev*.tar.bz2 -o ~/miniconda2/conda-bld/
+    binstar -t ${BINSTAR_TOKEN}  upload  --force --u omnia -p openpathsampling-dev $HOME/miniconda2/conda-bld/*/openpathsampling-dev*.tar.bz2
 fi
 
 if [[ "$python" != "2.7" ]]; then

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -32,4 +32,4 @@ source activate $python
 
 # install python pip packages
 PIP_ARGS="-U"
-$HOME/miniconda/envs/${python}/bin/pip install $PIP_ARGS -r devtools/ci/requirements-${python}.txt
+$HOME/miniconda2/envs/${python}/bin/pip install $PIP_ARGS -r devtools/ci/requirements-${python}.txt

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -18,7 +18,7 @@ bash $MINICONDA -b
 # This might make the --yes obsolete
 # conda config --set always_yes yes --set changeps1 no
 
-export PATH=$HOME/miniconda/bin:$PATH
+export PATH=$HOME/miniconda2/bin:$PATH
 
 hash -r
 


### PR DESCRIPTION
Miniconda seems to have change its default install path from `~/miniconda` to `~/miniconda2`.

This PR should fix it.

Resolves #354