### PR TITLE
TPSNetwork / TPSTransition

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -73,7 +73,7 @@ from analysis.tis_analysis import (
 from analysis.move_scheme import MoveScheme, DefaultScheme
 
 from analysis.network import (
-    MSTISNetwork, TransitionNetwork, MISTISNetwork
+    MSTISNetwork, TransitionNetwork, MISTISNetwork, TPSNetwork
 )
 
 from analysis.replica_network import (

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+import itertools
 
 import openpathsampling as paths
 from openpathsampling.base import StorableNamedObject
@@ -19,7 +20,29 @@ class TransitionNetwork(StorableNamedObject):
 
 #    def replica_exchange_matrix(self):
 
+class TPSNetwork(TransitionNetwork):
+    def __init_(self, initial_states, final_states):
+        self.initial_states = initial_states
+        self.final_states = final_states
+        all_initial = paths.join_volumes(initial_states)
+        all_initial.name = "|".join([v.name for v in initial_states])
+        all_final = paths.join_volumes(final_states)
+        all_final.name = "|".join([v.name for v in final_states])
+        self.sampling_transitions = [
+            paths.TPSTransition(all_initial, all_final)
+        ]
+        self.transitions = [
+            paths.TPSTransition(initial, final)
+            for (initial, final) in itertools.product(initial_states,
+                                                      final_states)
+            if initial != final
+        ]
+
+
+
 class TISNetwork(TransitionNetwork):
+    # NOTE: this is an abstract class with several properties used by many
+    # TIS-based networks
     # TODO: most of the analysis stuff should end up in here; the bigger
     # differences are in setup, not analysis
     def __init__(self):

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -67,16 +67,15 @@ class TPSNetwork(TransitionNetwork):
         ret_dict = {
             'transitions' : self.transitions,
             'x_sampling_transitions' : self._sampling_transitions,
-            'name' : self.name
         }
         return ret_dict
 
     @classmethod
     def from_dict(cls, dct):
         network = cls.__new__(cls)
+        super(TPSNetwork, network).__init__()
         network._sampling_transitions = dct['x_sampling_transitions']
         network.transitions = dct['transitions']
-        network.name = dct['name']
         return network
 
     @classmethod

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -49,8 +49,6 @@ class TPSNetwork(TransitionNetwork):
         except TypeError:
             final_states = [final_states]
 
-        self.initial_states = initial_states
-        self.final_states = final_states
         all_initial = paths.join_volumes(initial_states)
         all_initial.name = "|".join([v.name for v in initial_states])
         all_final = paths.join_volumes(final_states)
@@ -64,6 +62,31 @@ class TPSNetwork(TransitionNetwork):
                                                       final_states)
             if initial != final
         }
+
+    @classmethod
+    def from_state_pairs(cls, state_pairs):
+        sampling = []
+        transitions = {}
+        for (initial, final) in state_pairs:
+            if len(sampling) == 1:
+                sampling[0].add_transition(initial, final)
+            elif len(sampling) == 0:
+                sampling = [paths.TPSTransition(initial, final)]
+            else:
+                raise RuntimeError("More than one sampling transition for TPS?")
+
+            transitions[(initial, final)] = paths.TPSTransition(initial, final)
+        
+        network = cls.__new__(cls)
+        super(cls, network).__init__()
+        network._sampling_transitions = sampling
+        network.transitions = transitions
+        return network
+
+
+    @classmethod
+    def from_states_all_to_all(cls, states):
+        return cls(states, states)
 
 
 

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -40,6 +40,15 @@ class TransitionNetwork(StorableNamedObject):
 class TPSNetwork(TransitionNetwork):
     def __init__(self, initial_states, final_states):
         super(TPSNetwork, self).__init__()
+        try:
+            iter(initial_states)
+        except TypeError:
+            initial_states = [initial_states]
+        try:
+            iter(final_states)
+        except TypeError:
+            final_states = [final_states]
+
         self.initial_states = initial_states
         self.final_states = final_states
         all_initial = paths.join_volumes(initial_states)

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -63,6 +63,22 @@ class TPSNetwork(TransitionNetwork):
             if initial != final
         }
 
+    def to_dict(self):
+        ret_dict = {
+            'transitions' : self.transitions,
+            'x_sampling_transitions' : self._sampling_transitions,
+            'name' : self.name
+        }
+        return ret_dict
+
+    @classmethod
+    def from_dict(cls, dct):
+        network = cls.__new__(cls)
+        network._sampling_transitions = dct['x_sampling_transitions']
+        network.transitions = dct['transitions']
+        network.name = dct['name']
+        return network
+
     @classmethod
     def from_state_pairs(cls, state_pairs):
         sampling = []

--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -72,13 +72,28 @@ class TPSTransition(Transition):
     """
     def __init__(self, stateA, stateB, name=None):
         super(TPSTransition, self).__init__(stateA, stateB)
-        self.name = name
+        if name is not None:
+            self.name = name
         if not hasattr(self, "ensembles"):
             self.ensembles = [paths.SequentialEnsemble([
                 paths.AllInXEnsemble(stateA) & paths.LengthEnsemble(1),
                 paths.AllOutXEnsemble(stateA | stateB),
                 paths.AllInXEnsemble(stateB) & paths.LengthEnsemble(1)
             ])]
+
+    def to_dict(self):
+        return {
+            'stateA' : self.stateA,
+            'stateB' : self.stateB,
+            'ensembles' : self.ensembles,
+            'name' : self.name
+        }
+
+    @classmethod
+    def from_dict(cls, dct):
+        mytrans = TPSTransition(dct['stateA'], dct['stateB'], dct['name'])
+        mytrans.ensembles = dct['ensembles']
+        return mytrans
 
     def add_transition(self, stateA, stateB):
         new_ens = paths.SequentialEnsemble([

--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -75,9 +75,9 @@ class TPSTransition(Transition):
         self.name = name
         if not hasattr(self, "ensembles"):
             self.ensembles = [paths.SequentialEnsemble([
-                paths.AllInXEnsemble(all_initial) & paths.LengthEnsemble(1),
-                paths.AllOutXEnsemble(all_initial | all_final),
-                paths.AllInXEnsemble(all_initial) & paths.LengthEnsemble(1)
+                paths.AllInXEnsemble(stateA) & paths.LengthEnsemble(1),
+                paths.AllOutXEnsemble(stateA | stateB),
+                paths.AllInXEnsemble(stateB) & paths.LengthEnsemble(1)
             ])]
 
 

--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -80,6 +80,16 @@ class TPSTransition(Transition):
                 paths.AllInXEnsemble(stateB) & paths.LengthEnsemble(1)
             ])]
 
+    def add_transition(self, stateA, stateB):
+        new_ens = paths.SequentialEnsemble([
+            paths.AllInXEnsemble(stateA) & paths.LengthEnsemble(1),
+            paths.AllOutXEnsemble(stateA | stateB),
+            paths.AllInXEnsemble(stateB) & paths.LengthEnsemble(1)
+        ])
+        try:
+            self.ensembles[0] = self.ensembles[0] | new_ens
+        except AttributeError:
+            self.ensembles = [new_ens]
 
 
 class TISTransition(Transition):

--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -70,9 +70,17 @@ class TPSTransition(Transition):
     """
     Transition using TPS ensembles
     """
-    def __init__(self, stateA, stateB):
+    def __init__(self, stateA, stateB, name=None):
         super(TPSTransition, self).__init__(stateA, stateB)
-        #self.ensembles = [paths.TPSEnsemble(stateA, stateB)]
+        self.name = name
+        if not hasattr(self, "ensembles"):
+            self.ensembles = [paths.SequentialEnsemble([
+                paths.AllInXEnsemble(all_initial) & paths.LengthEnsemble(1),
+                paths.AllOutXEnsemble(all_initial | all_final),
+                paths.AllInXEnsemble(all_initial) & paths.LengthEnsemble(1)
+            ])]
+
+
 
 class TISTransition(Transition):
     """

--- a/openpathsampling/tests/test_helpers.py
+++ b/openpathsampling/tests/test_helpers.py
@@ -124,12 +124,12 @@ class CallIdentity(object):
 class AtomCounter(object):
     '''Let's be honest: that's all we're using the simulation.system object
     for. So I'll duck-punch.'''
-    def __init__(self, natoms):
-        self.natoms = natoms
+    def __init__(self, n_atoms):
+        self.n_atoms = n_atoms
 
     def getNumParticles(self):
         '''QUAAAAACK'''
-        return self.natoms
+        return self.n_atoms
 
 class SimulationDuckPunch(object):
     '''This is what happens when you find a stranger in the Alps.'''

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -115,18 +115,31 @@ class testTPSNetwork(object):
     def test_initialization_2state(self):
         network2a = TPSNetwork(initial_states=[self.stateA],
                                final_states=[self.stateB])
+        assert_equal(len(network2a.sampling_transitions), 1)
+        assert_equal(len(network2a.transitions), 1)
         network2b = TPSNetwork(initial_states=self.stateA,
                                final_states=self.stateB)
-        assert_equal(len(network2a.sampling_transitions), 1)
         assert_equal(len(network2b.sampling_transitions), 1)
-        assert_equal(len(network2a.transitions), 1)
         assert_equal(len(network2b.transitions), 1)
-        raise SkipTest
+        network2c = TPSNetwork.from_state_pairs([(self.stateA, self.stateB)])
+        assert_equal(len(network2c.sampling_transitions), 1)
+        assert_equal(len(network2c.transitions), 1)
+
 
     def test_initialization_3state(self):
         states = [self.stateA, self.stateB, self.stateC]
         network3a = TPSNetwork(initial_states=states, final_states=states)
         assert_equal(len(network3a.sampling_transitions), 1)
         assert_equal(len(network3a.transitions), 6)
-        raise SkipTest
+        network3b = TPSNetwork.from_states_all_to_all(states)
+        assert_equal(len(network3b.sampling_transitions), 1)
+        assert_equal(len(network3b.transitions), 6)
+        network3c = TPSNetwork.from_state_pairs([(self.stateA, self.stateB),
+                                                 (self.stateA, self.stateC),
+                                                 (self.stateB, self.stateA),
+                                                 (self.stateB, self.stateC),
+                                                 (self.stateC, self.stateA),
+                                                 (self.stateC, self.stateB)])
+        assert_equal(len(network3c.sampling_transitions), 1)
+        assert_equal(len(network3c.transitions), 6)
 

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -112,10 +112,21 @@ class testTPSNetwork(object):
         self.stateB = paths.CVRangeVolume(xval, -0.1, 0.1)
         self.stateC = paths.CVRangeVolume(xval, 0.5, float("inf"))
 
-    def test_initialization(self):
-        network1 = TPSNetwork(initial_states=[self.stateA],
-                              final_states=[self.stateB])
-        #network2 = TPSNetwork(initial_states=stateA,
-                              #final_states=stateB)
+    def test_initialization_2state(self):
+        network2a = TPSNetwork(initial_states=[self.stateA],
+                               final_states=[self.stateB])
+        network2b = TPSNetwork(initial_states=self.stateA,
+                               final_states=self.stateB)
+        assert_equal(len(network2a.sampling_transitions), 1)
+        assert_equal(len(network2b.sampling_transitions), 1)
+        assert_equal(len(network2a.transitions), 1)
+        assert_equal(len(network2b.transitions), 1)
+        raise SkipTest
+
+    def test_initialization_3state(self):
+        states = [self.stateA, self.stateB, self.stateC]
+        network3a = TPSNetwork(initial_states=states, final_states=states)
+        assert_equal(len(network3a.sampling_transitions), 1)
+        assert_equal(len(network3a.transitions), 6)
         raise SkipTest
 

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -156,10 +156,16 @@ class testTPSNetwork(object):
                                        topology=topol)
         states = [self.stateA, self.stateB, self.stateC]
         network_a = TPSNetwork(initial_states=states, final_states=states)
+        assert_equal(len(network_a.sampling_transitions), 1)
+        assert_equal(len(network_a.transitions), 6)
         storage_w = paths.storage.Storage(fname, "w", self.template)
         storage_w.save(network_a)
         storage_w.sync_all()
 
-        # storage_r = paths.storage.AnalysisStorage(fname)
-        # network_b = storage_r.networks[0]
+        storage_r = paths.storage.AnalysisStorage(fname)
+        network_b = storage_r.networks[0]
+        assert_equal(len(network_b.sampling_transitions), 1)
+        assert_equal(len(network_b.transitions), 6)
 
+        if os.path.isfile(fname):
+            os.remove(fname)

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -107,10 +107,12 @@ class testMSTISNetwork(object):
 
 class testTPSNetwork(object):
     def setup(self):
-        xval = paths.CV_Function(name="xA", f=lambda s : s.xyz[0][0])
+        from test_helpers import CallIdentity
+        xval = CallIdentity()
         self.stateA = paths.CVRangeVolume(xval, float("-inf"), -0.5)
         self.stateB = paths.CVRangeVolume(xval, -0.1, 0.1)
         self.stateC = paths.CVRangeVolume(xval, 0.5, float("inf"))
+        
 
     def test_initialization_2state(self):
         network2a = TPSNetwork(initial_states=[self.stateA],
@@ -142,4 +144,22 @@ class testTPSNetwork(object):
                                                  (self.stateC, self.stateB)])
         assert_equal(len(network3c.sampling_transitions), 1)
         assert_equal(len(network3c.transitions), 6)
+
+    def test_storage(self):
+        import os
+        fname = "tps_network_storage_test.nc"
+        if os.path.isfile(fname):
+            os.remove(fname)
+        topol = paths.ToyTopology(n_spatial=1, masses=[1.0], pes=None)
+        self.template = paths.Snapshot(coordinates=[[0.0]], 
+                                       velocities=[[0.0]], 
+                                       topology=topol)
+        states = [self.stateA, self.stateB, self.stateC]
+        network_a = TPSNetwork(initial_states=states, final_states=states)
+        storage_w = paths.storage.Storage(fname, "w", self.template)
+        storage_w.save(network_a)
+        storage_w.sync_all()
+
+        # storage_r = paths.storage.AnalysisStorage(fname)
+        # network_b = storage_r.networks[0]
 

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -105,3 +105,17 @@ class testMSTISNetwork(object):
         assert_equal(len(self.mstis.from_state[self.stateC].ensembles), 2)
 
 
+class testTPSNetwork(object):
+    def setup(self):
+        xval = paths.CV_Function(name="xA", f=lambda s : s.xyz[0][0])
+        self.stateA = paths.CVRangeVolume(xval, float("-inf"), -0.5)
+        self.stateB = paths.CVRangeVolume(xval, -0.1, 0.1)
+        self.stateC = paths.CVRangeVolume(xval, 0.5, float("inf"))
+
+    def test_initialization(self):
+        network1 = TPSNetwork(initial_states=[self.stateA],
+                              final_states=[self.stateB])
+        #network2 = TPSNetwork(initial_states=stateA,
+                              #final_states=stateB)
+        raise SkipTest
+


### PR DESCRIPTION
Resolves #360

Current implementation is as version 3 in #360, with classmethods for version 1 (`from_state_pairs`) and version 2 (`from_states_all_to_all`).

Note that, currently, TIS uses the network and transition objects to hold analysis functions as well. None of those are yet implemented for TPSNetworks and Transitions.

- [x] TPSTransition
- [x] TPSNetwork, default build of ensembles
- [x] `TPSNetwork.from_state_pairs`
- [x] `TPSNetwork.from_states_all_to_all`
- [x] Tests for the construction of `TPSNetwork` using each method
- [x] Store and reload of `TPSNetwork`, `TPSTransition`

Also, this will only have a little bit of testing: I only checked that the desired number of transitions are created. It sounded from email like @bolhuis wanted to use something like this soon, so I wanted to toss something together quickly.

For the most simple TPS network, going from `stateA` to `stateB` (without the reverse process), you can do any of:

```python
versionA = TPSNetwork(stateA, stateB)
versionB = TPSNetwork(initial_states=[stateA], final_states=[stateB])
versionC = TPSNetwork.from_state_pairs(state_pairs=[(stateA, stateB)])
```

All of those will give you the same result. 