### PR TITLE
Properly abstract MoveStrategy

### DIFF
--- a/openpathsampling/analysis/move_strategy.py
+++ b/openpathsampling/analysis/move_strategy.py
@@ -1,5 +1,6 @@
 import itertools
 import collections
+import abc
 
 import openpathsampling as paths
 from openpathsampling.base import StorableNamedObject
@@ -86,6 +87,9 @@ class MoveStrategy(StorableNamedObject):
     level
     """
     _level = -1
+
+    __metaclass__ = abc.ABCMeta
+
     def __init__(self, ensembles, group, replace):
         super(MoveStrategy, self).__init__()
         self.ensembles = ensembles
@@ -174,6 +178,7 @@ class MoveStrategy(StorableNamedObject):
 
         return res_ensembles
 
+    @abc.abstractmethod
     def make_movers(self, scheme):
         """
         Makes the movers associated with this strategy.

--- a/openpathsampling/tests/testmovestrategy.py
+++ b/openpathsampling/tests/testmovestrategy.py
@@ -19,6 +19,10 @@ logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 
+class MockMoveStrategy(MoveStrategy):
+    def make_movers(self, scheme):
+        return None
+
 def find_mover(scheme, group, sig):
     mover = None
     for m in scheme.movers[group]:
@@ -56,7 +60,7 @@ class MoveStrategyTestSetup(object):
 
 class testMoveStrategy(MoveStrategyTestSetup):
     def test_levels(self):
-        strategy = MoveStrategy(ensembles=None, group="test", replace=True)
+        strategy = MockMoveStrategy(ensembles=None, group="test", replace=True)
         assert_equal(strategy.level, -1)
         assert_equal(strategy.replace_signatures, False)
         assert_equal(strategy.replace_movers, False)
@@ -74,7 +78,8 @@ class testMoveStrategy(MoveStrategyTestSetup):
         assert_equal(strategy.replace_movers, False)
 
     def test_get_ensembles(self):
-        self.strategy = MoveStrategy(ensembles=None, group="test", replace=True)
+        self.strategy = MockMoveStrategy(ensembles=None, group="test", 
+                                         replace=True)
         scheme = MoveScheme(self.network)
         # load up the relevant ensembles to test against
         transition_ensembles = []


### PR DESCRIPTION
Following @jhprinz's switching of other things to proper AbstractBaseClasses in #375, this does the same for MoveStrategies.

Ready to merge when tests pass.