### PR TITLE
quick fix for visualization bug

### DIFF
--- a/openpathsampling/pathmover.py
+++ b/openpathsampling/pathmover.py
@@ -582,7 +582,7 @@ class EngineMover(SampleMover):
         trial_point = paths.ShootingPoint(
             shooting_point.selector,
             trial_trajectory,
-            shooting_point.index
+            trial_trajectory.index(shooting_point.snapshot)
         )
 
         return trial_point

--- a/openpathsampling/visualize.py
+++ b/openpathsampling/visualize.py
@@ -1007,7 +1007,7 @@ class PathTreeBuilder(object):
                     if mover_type is paths.BackwardShootMover:
                         color = "green"
                         self.renderer.add(
-                            self.renderer.v_connection(shift + new_index + 1,
+                            self.renderer.v_connection(shift + new_index,
                                                        p_y[old_conf_idx], t_count,
                                                        color)
                         )
@@ -1022,7 +1022,7 @@ class PathTreeBuilder(object):
                         color = "red"
 
                         self.renderer.add(
-                            self.renderer.v_connection(shift + new_index,
+                            self.renderer.v_connection(shift + new_index + 1,
                                                        p_y[old_conf_idx], t_count,
                                                        color)
                         )


### PR DESCRIPTION
This should fix the problems with PathTreeVisualization for now.

It fixes a problem in SamplePathMover that will set the correct index for the trial shooting point.