### PR TITLE
Documentation updates

### DIFF
--- a/docs/examples/mstis.rst
+++ b/docs/examples/mstis.rst
@@ -1,10 +1,14 @@
 Multiple State TIS Example
 ==========================
 
-This example consists of two notebooks: one to prepare and run the system,
-and one to do the analysis after.
+This example consists of three notebooks: one to obtain initial
+trajectories, one to perform the TIS simualtion, and one to do the analysis
+after.
 
-.. notebook:: examples/ipython/multistate_system_setup.ipynb
+.. notebook:: examples/ipython/mstis_bootstrap.ipynb
+   :skip_exceptions:
+
+.. notebook:: examples/ipython/mstis.ipynb
    :skip_exceptions:
 
 .. notebook:: examples/ipython/mstis_analysis.ipynb

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,10 @@ OpenPathSampling
 
 A Python toolkit to run PathSampling algorithms.
 
+Participate in the development process on GitHub_
+
+.. _GitHub: http://github.com/choderalab/openpathsampling
+
 --------------------------------------------------------------------------------
 
 Documentation

--- a/examples/ipython/transitions_and_networks.ipynb
+++ b/examples/ipython/transitions_and_networks.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transitions and Networks\n",
+    "\n",
+    "Different path sampling approaches use different kinds of ensembles. But what they all share in common is that those ensembles represent some network of transitions.\n",
+    "\n",
+    "Under most circumstances, the user can directly work with `TransitionNetwork`s, and never needs to work directly with `Ensemble`s. This document describes the internal structure of `TransitionsNetwork`s, and explains how to customize that structure with different ensembles if so desired.\n",
+    "\n",
+    "This also covers some of the interface between `TransitionNetwork`s and `MoveStrategy` objects. When developing new methodologies, this interface allows for high levels of flexibility. A new `TransitionNetwork` could be combined with a customized `MoveStrategy` to develop all sorts of path-sampling-like approaches."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `Network`s are made of `Transition`s\n",
+    "\n",
+    "A transition describes a set of paths with certain allowed initial and final conditions. There are two groups of transitions that are important when working with networks. First, there are the `sampling_transitions`, which are what are actually sampled by the dynamics. Then there are `analysis_transitions` (or just `transitions`) which are the subjects of analysis.\n",
+    "\n",
+    "The difference between these is easily described in the context of MSTIS. With MSTIS, you use one set of ensembles to sample the transitions from a given state to all other states. So you would sample $A\\to (B \\text{ or } C)$, but the analysis transitions would include separate studies of $A\\to B$ and $A\\to C$.\n",
+    "\n",
+    "The network is defined by the combination of what the underlying transitions to study are, and the approach used to study them. It defines a set of path ensembles which are sampled during the dynamics, and the way to combine those afterward into results that connect to physical meaning."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Handcrafting `Network`s\n",
+    "\n",
+    "Beyond the simple tools to customize the networks you study, you can manually create them with whatever complexity you desire. The `Network` level of code is designed to interact with the `MoveScheme` and `MoveStrategy` code, as well as with some of the analysis tools. As long as you implement a few items, your custom `Network` will work seamlessly with those.\n",
+    "\n",
+    "The main point is that there are two aspects of the network: there's the sampling network, which is organizes the ensembles\n",
+    "\n",
+    "#### Handcrafting the sampling network\n",
+    "\n",
+    "The sampling network consists of three objects:\n",
+    "\n",
+    "* `_sampling_transitions`: a list of transitions; contains all the normal ensembles\n",
+    "* `special_ensembles`: a dictionary with strings for keys, describing the type of ensemble, and dictionaries for values. Those value dictionaries have the ensembles themselves as keys, and a list of associated transitions as values.\n",
+    "* `hidden_ensembles`: this list is empty when built by the network, and is set by the MoveScheme if necessary\n",
+    "\n",
+    "The special ensembles need to have the correct key names to work with the `MoveScheme` and `MoveStrategy` subsystem. These are `'minus'` for the minus interfaces, and `'ms_outer'` for the multiple state outer interfaces.\n",
+    "\n",
+    "If you do that, then `MoveStrategy` and `MoveScheme` will work with your networks.\n",
+    "\n",
+    "#### Handcrafting the analysis network\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
- [x] New notebook about transitions and networks (still in progress)
- [x] Add link to GitHub on main page of OPS docs (although someone should make one of those nice "Fork me on Github" things)
- [x] Updated docs to use the 3-notebook versions of MSTIS stuff (replace multistate_setup with mstis_bootstrap and mstis)

Just docs. Merge at will.