### PR TITLE
Locked scheme saving

### DIFF
--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -41,34 +41,20 @@ class MoveScheme(StorableNamedObject):
 
     def to_dict(self):
         ret_dict = {
-            #'movers' : self.movers,
+            'movers' : self.movers,
             'network' : self.network,
-            #'choice_probability' : self.choice_probability,
+            'choice_probability' : self.choice_probability,
             'balance_partners' : self.balance_partners,
             'root_mover' : self.root_mover
         }
-        try:
-            ret_dict['movers'] = self.movers
-        except AttributeError:
-            pass # unset movers dict is allowed
-        try:
-            ret_dict['choice_probability'] = self.choice_probability
-        except AttributeError:
-            pass # unset choice_probability allowed
         return ret_dict
 
     @classmethod
     def from_dict(cls, dct):
         scheme = cls.__new__(cls)
         scheme.__init__(dct['network'])
-        try:
-            scheme.movers = dct['movers']
-        except KeyError:
-            pass # unset movers dict is allowed
-        try:
-            scheme.choice_probability = dct['choice_probability']
-        except KeyError:
-            pass # unset choice_probability allowed
+        scheme.movers = dct['movers']
+        scheme.choice_probability = dct['choice_probability']
         scheme.balance_partners = dct['balance_partners']
         scheme.root_mover = dct['root_mover']
         return scheme
@@ -603,36 +589,38 @@ class LockedMoveScheme(MoveScheme):
     def apply_strategy(self, strategy):
         raise TypeError("Locked schemes cannot apply strategies")
 
+    def to_dict(self):
+        # things that we always have (from MoveScheme)
+        ret_dict = {
+            'network' : self.network,
+            'balance_partners' : self.balance_partners,
+            'root_mover' : self.root_mover
+        }
+        # things that LockedMoveScheme overrides
+        ret_dict['movers'] = self._movers
+        ret_dict['choice_probability'] = self._choice_probability
+        return ret_dict
+
     @property
     def choice_probability(self):
-        try:
+        if self._choice_probability == {}:
+            raise AttributeError("'choice_probability' must be manually " + 
+                                 "set in 'LockedMoveScheme'")
+        else:
             return self._choice_probability
-        except AttributeError as e:
-            gap = "\n                "
-            failmsg = (gap + "'choice_probability' must be manually set in " +
-                       "'LockedMoveScheme'.")
-            e.args = tuple([e.args[0] + failmsg] + list(e.args[1:]))
-            raise
 
     @choice_probability.setter
     def choice_probability(self, vals):
-        if vals != {}:
-            # default does not set the internal version here
-            self._choice_probability = vals
+        self._choice_probability = vals
 
     @property
     def movers(self):
-        try:
+        if self._movers == {}:
+            raise AttributeError("'movers' must be manually " + 
+                                 "set in 'LockedMoveScheme'")
+        else:
             return self._movers
-        except AttributeError as e:
-            gap = "\n                "
-            failmsg = (gap + "'movers' must be manually set in" + 
-                       "'LockedMoveScheme'.")
-            e.args = tuple([e.args[0] + failmsg] + list(e.args[1:]))
-            raise
 
     @movers.setter
     def movers(self, vals):
-        if vals != {}:
-            # default does not set the internal version here
-            self._movers = vals
+        self._movers = vals

--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -41,20 +41,34 @@ class MoveScheme(StorableNamedObject):
 
     def to_dict(self):
         ret_dict = {
-            'movers' : self.movers,
+            #'movers' : self.movers,
             'network' : self.network,
-            'choice_probability' : self.choice_probability,
+            #'choice_probability' : self.choice_probability,
             'balance_partners' : self.balance_partners,
             'root_mover' : self.root_mover
         }
+        try:
+            ret_dict['movers'] = self.movers
+        except AttributeError:
+            pass # unset movers dict is allowed
+        try:
+            ret_dict['choice_probability'] = self.choice_probability
+        except AttributeError:
+            pass # unset choice_probability allowed
         return ret_dict
 
     @classmethod
     def from_dict(cls, dct):
         scheme = cls.__new__(cls)
         scheme.__init__(dct['network'])
-        scheme.movers = dct['movers']
-        scheme.choice_probability = dct['choice_probability']
+        try:
+            scheme.movers = dct['movers']
+        except KeyError:
+            pass # unset movers dict is allowed
+        try:
+            scheme.choice_probability = dct['choice_probability']
+        except KeyError:
+            pass # unset choice_probability allowed
         scheme.balance_partners = dct['balance_partners']
         scheme.root_mover = dct['root_mover']
         return scheme


### PR DESCRIPTION
Resolves #418.

Certain attributes for analysis can't be set algorithmically in a `LockedMoveScheme` (in normal schemes, they can be set algorithmically by the `MoveStrategy` objects). If trying to run analysis using a `LockedMoveScheme` without these attributes set, the desired behavior is to raise an `AttributeError` with a clear error message saying that they need to be manually set.

The problem was that accessing those (unset) attributes raised the error -- but, of course, storage needs to access the attributes (in case they exist) to save them.

Fix was to switch some over-fancy stuff based on not *having* the attribute to allow the attribute a default "empty" value (for both `movers` and `choice_probability` in `LockedMoveScheme`). These are attributes that are needed for analysis, and if they are empty, analysis will still error, but storage works.

Working example to copy-paste that this works now:

```python
import openpathsampling as paths
from openpathsampling import VolumeFactory as vf
import numpy as np

# setting up a fake system is harder than most of the rest of this
import openpathsampling.toy_dynamics as toys

pes = toys.toy_pes.Gaussian(-1.0, [1.0, 1.0], [0.0, 0.0])

topology=paths.ToyTopology(
    n_spatial = 2,
    masses =[1.0, 1.0],
    pes = pes
)

template = paths.ToySnapshot(
    coordinates=np.array([[-0.5, -0.5]]), 
    velocities=np.array([[0.0,0.0]]),
    topology=topology
)

cvA = paths.CV_Function(name="xA", f=lambda s : s.xyz[0][0])
stateA = paths.CVRangeVolume(cvA, float("-inf"), -0.5)
stateB = paths.CVRangeVolume(cvA, 0.5, float("inf"))

len1 = paths.LengthEnsemble(1)
ens = paths.SequentialEnsemble([stateA & len1, ~stateA & ~stateB, stateB & len1])

shooter = paths.OneWayShootingMover(ensemble=ens, selector=paths.UniformSelector())
scheme = paths.LockedMoveScheme(root_mover=shooter)

storage = paths.Storage("tmpfile.nc", mode="w", template=template)
storage.save(scheme)
storage.close()

st2 = paths.AnalysisStorage("tmpfile.nc")
scheme2 = st2.schemes[0]
print scheme2.root_mover
```

That should output `OneWayShooting`.

This should be ready to merge as soon as tests pass. Assigning to @jhprinz.