### PR TITLE
Getting the actual git hash for editable installs

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -98,3 +98,10 @@ from pathmovechange import (
 )
 
 from storage.storage import Storage, AnalysisStorage
+
+def git_HEAD():
+    from subprocess import check_output
+    import os.path
+    git_dir = os.path.dirname(os.path.realpath(__file__))
+    return check_output(["git", "-C", git_dir, "rev-parse", "HEAD"])[:-1]
+    # chops the newline at the end


### PR DESCRIPTION
When working with alpha testers (i.e., Abel) it can be very helpful to check that the installed version of OPS is actually on the git commit that the user thinks it is. `version.py` is only set when the user runs `setup.py`, so we don't want to require that every time. I added a little function to `__init__.py` that gives the git commit hash if the file is in a git repo (it will raise an error otherwise, I think). This is useful for debugging when we can't tell exactly which version of the code the user is using. We might move it to another module, but I wasn't sure which module was appropriate (or if we need a new one).

Anyway, this should be ready to review at any time.