### PR TITLE
DynamicsEngine.generate_n_frames

### DIFF
--- a/openpathsampling/dynamics_engine.py
+++ b/openpathsampling/dynamics_engine.py
@@ -333,6 +333,31 @@ class DynamicsEngine(StorableNamedObject):
     def generate_next_frame(self):
         raise NotImplementedError('Next frame generation must be implemented!')
 
+
+    def generate_n_frames(self, n_frames=1):
+        """Generates n_frames, from but not including the current snapshot.
+        
+        This generates a fixed number of frames at once. If you desire the
+        reversed trajectory, you can reverse the returned trajectory.
+
+        Parameters
+        ----------
+        n_frames : integer
+            number of frames to generate
+
+        Returns
+        -------
+        paths.Trajectory()
+            the `n_frames` of the trajectory following (and not including)
+            the initial `current_snapshot`
+        """
+        self.start()
+        traj = paths.Trajectory([self.generate_next_frame() 
+                                 for i in range(n_frames)])
+        self.stop(traj)
+        return traj
+        
+
     @classmethod
     def check_snapshot_type(cls, snapshot):
         if not isinstance(snapshot, cls.base_snapshot_type):


### PR DESCRIPTION
Adds a function to `DynamicsEngine` to get multiple frames at once (`generate_n_frames`). This process is only implemented in the forward direction. If the user wants the reverse trajectory, the user can explicitly reverse -- under most such circumstances, it nerateould make more sense to use the existing infrastructure, if that is what is desired. This is intended for the many non-path-sampling examples where we generate a fixed length trajectory from an initial point.

Overriding this default implementation could (with a few other tricks) allow for much faster implementations for fixed-length trajectories on small systems.