### PR TITLE
Calculate flux through arbitrary interface with SingleTrajectoryAnalysis

### DIFF
--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -156,7 +156,7 @@ class SingleTrajectoryAnalysis(object):
             seg[1:-1] for seg in transition_ensemble.split(trajectory)
         ]
 
-    def analyze_flux(self, trajectory, state):
+    def analyze_flux(self, trajectory, state, interface=None):
         """Analysis to obtain flux segments for given state.
 
         Parameters
@@ -166,8 +166,13 @@ class SingleTrajectoryAnalysis(object):
         state : :class:`.Volume`
             state volume to characterize. Must be one of the states in the
             transition
+        interface : :class:`.Volume` or None
+            interface to calculate the flux through. If `None`, same as
+            `state`
         """
         other = list(set([self.stateA, self.stateB]) - set([state]))[0]
+        if interface is None:
+            interface = state
         counts_out = paths.SequentialEnsemble([
             paths.AllInXEnsemble(state) & paths.LengthEnsemble(1),
             paths.AllOutXEnsemble(state | other),

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -190,6 +190,31 @@ class SingleTrajectoryAnalysis(object):
         for seg in flux_out_segments:
             self.flux_segments[state]['out'] += [seg[1:-1]]
 
+    def new_analyze_flux(self, trajectory, state, interface=None):
+        other = list(set([self.stateA, self.stateB]) - set([state]))[0]
+        if interface is None:
+            interface = state
+        crossed = ~(interface | state | other)
+        last_visit = {
+            state: float('nan'),
+            crossed: float('nan'),
+            other: float('-inf')
+        }
+
+        flux_segments = self.flux_segments[state]
+        current_traj_type = None
+        for i in range(len(trajectory)):
+            frame = trajectory[i]
+            # figure out which volume the frame is in (there had better only
+            # be one answer) and assign the last_visited for that
+            frame_vols = [vol for vol in last_visit.keys() if vol(frame)]
+            assert len(frame_vols) == 1
+            frame_vol = frame_vols[0]
+            previous_visit = last_visit[frame_vol]
+            last_visit[frame_vol] = i
+            
+
+
     def analyze(self, trajectories):
         """Full analysis of a trajectory or trajectories.
 

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -120,9 +120,18 @@ class testSingleTrajectoryAnalysis(object):
         assert_equal(flux_segs_A['out'][3], core_traj[15:17])
 
     def test_analyze_flux_with_interface(self):
-        flux_interface_traj_str = ""
-        flux_traj = self._make_traj(flux_interface_traj_str)
+        flux_iface_traj_str = "aixixaiaxiixiaxaixbxbixiaaixiai"
+        # frame numbers        0    5    0    5    0    5    0
+        # in (I) or out (O)      OOOIIIOOOOOIOII       IIIOO 
+        assert_equal(len(flux_iface_traj_str), 31) # check I counted correctly
+        flux_traj = self._make_traj(flux_iface_traj_str)
+        self.analyzer.reset_analysis()
         self.analyzer.analyze_flux(flux_traj, self.stateA, self.interfaceA0)
+        flux_segs_A = self.analyzer.flux_segments[self.stateA]
+        assert_equal(flux_segs_A['in'], [flux_traj[5:8], flux_traj[13:14],
+                                         flux_traj[15:17], flux_traj[24:27]])
+        assert_equal(flux_segs_A['out'], [flux_traj[2:5], flux_traj[8:13],
+                                          flux_traj[14:15], flux_traj[27:29]])
         raise SkipTest
 
     def test_analyze(self):

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -16,9 +16,11 @@ class testSingleTrajectoryAnalysis(object):
     def setup(self):
         op = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])
         vol1 = paths.CVRangeVolume(op, 0.1, 0.5)
+        vol2 = paths.CVRangeVolume(op, -0.1, 0.7)
         vol3 = paths.CVRangeVolume(op, 2.0, 2.5)
         self.stateA = vol1
         self.stateB = vol3
+        self.interfaceA0 = vol2
 
         self.stateX = ~vol1 & ~vol3
 
@@ -33,7 +35,8 @@ class testSingleTrajectoryAnalysis(object):
         char_to_parameters = {
             'a' : {'lo' : 0.1, 'hi' : 0.5},
             'b' : {'lo' : 2.0, 'hi' : 2.5},
-            'x' : {'lo' : 0.5, 'hi' : 2.0}
+            'i' : {'lo' : 0.5, 'hi' : 0.7},
+            'x' : {'lo' : 0.7, 'hi' : 2.0}
         }
         delta = 0.05
         for char in traj_str:
@@ -115,6 +118,12 @@ class testSingleTrajectoryAnalysis(object):
         assert_equal(flux_segs_A['out'][1], core_traj[3:4])
         assert_equal(flux_segs_A['out'][2], core_traj[7:9])
         assert_equal(flux_segs_A['out'][3], core_traj[15:17])
+
+    def test_analyze_flux_with_interface(self):
+        flux_interface_traj_str = ""
+        flux_traj = self._make_traj(flux_interface_traj_str)
+        self.analyzer.analyze_flux(flux_traj, self.stateA, self.interfaceA0)
+        raise SkipTest
 
     def test_analyze(self):
         # only test that it runs -- correctness testing in the others

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -106,6 +106,7 @@ class testSingleTrajectoryAnalysis(object):
         # in (I) or out (O):   OIOIIIOOI   IIOO 
         core_traj = self._make_traj(flux_core_test_str)
         self.analyzer.new_analyze_flux(core_traj, self.stateA)
+        self.analyzer.reset_analysis()
         self.analyzer.analyze_flux(core_traj, self.stateA)
         flux_segs_A = self.analyzer.flux_segments[self.stateA]
         assert_equal(len(flux_segs_A['in']), 4)

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -105,8 +105,6 @@ class testSingleTrajectoryAnalysis(object):
         # frame numbers       0    5    0    5    0
         # in (I) or out (O):   OIOIIIOOI   IIOO 
         core_traj = self._make_traj(flux_core_test_str)
-        self.analyzer.new_analyze_flux(core_traj, self.stateA)
-        self.analyzer.reset_analysis()
         self.analyzer.analyze_flux(core_traj, self.stateA)
         flux_segs_A = self.analyzer.flux_segments[self.stateA]
         assert_equal(len(flux_segs_A['in']), 4)

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -105,6 +105,7 @@ class testSingleTrajectoryAnalysis(object):
         # frame numbers       0    5    0    5    0
         # in (I) or out (O):   OIOIIIOOI   IIOO 
         core_traj = self._make_traj(flux_core_test_str)
+        self.analyzer.new_analyze_flux(core_traj, self.stateA)
         self.analyzer.analyze_flux(core_traj, self.stateA)
         flux_segs_A = self.analyzer.flux_segments[self.stateA]
         assert_equal(len(flux_segs_A['in']), 4)


### PR DESCRIPTION
The version of the single trajectory analysis I previously included calculates the flux out of the state. However, we’re often interested in the flux out of the state and through a given interface. This PR adds the option of adding an interface to the flux calculation. By default, the interface is equal to the state, which gives the same result as before.

- [x] Implement flux through interface
- [x] Thorough tests to include flux through interface
- [x] Clean up docstrings

This does not change anything that is currently set up, and won’t even make it so that the default `.analyze` function includes the interface. If the user wants to calculate the flux this way, the user has to ask for it explicitly.

One nice trick is that, in implementing this, I recognized that the flux calculation was very similar to a state lifetime calculation. That means they can both use the same code: `get_lifetime_segments`. For now, that is in `SingleTrajectoryAnalysis`. However, it might make sense to make it part of `Trajectory`, along with `summarize_by_volumes`. (Otherwise, perhaps `summarize_by_volumes` should be moved out of `Trajectory`?)