### PR TITLE
More cleanup of Single Trajectory Analysis

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -11,7 +11,8 @@ from analysis.tis_analysis import (
     TISTransition, Transition, TPSTransition
 )
 from analysis.single_trajectory_analysis import (
-    SingleTrajectoryAnalysis 
+    SingleTrajectoryAnalysis,
+    TrajectorySegmentContainer
 )
 
 from collectivevariable import CV_Function, CV_MDTraj_Function, CV_MSMB_Featurizer, \

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -3,17 +3,24 @@ import numpy as np
 
 class TrajectorySegmentContainer(object):
     def __init__(self, segments, dt=None):
-        self.segments = segments
+        self._segments = segments
         self.dt = dt
 
+    @property
     def n_frames(self):
         return np.array([len(seg) for seg in self.segments])
 
+    @property
     def times(self):
         if self.dt is None:
             raise RuntimeError("No time delta set")
             # TODO: this might become a logger.warn
         return np.array([len(seg)*self.dt for seg in self.segments])
+
+    @property
+    def segments(self):
+        # segments cannot be set
+        return self._segments
 
     def __add__(self, other):
         if self.dt != other.dt:
@@ -22,9 +29,27 @@ class TrajectorySegmentContainer(object):
             )
         return TrajectorySegmentContainer(self.segments + other.segments,
                                           self.dt)
-    
+
+    def __iadd__(self, other):
+        # in this case, we ignore dt
+        self.segments += other.segments
+
     def __len__(self):
         return len(self.segments)
+
+    def __contains__(self, item):
+        return item in self.segments
+
+    def __iter__(self):
+        return self.segments.__iter__()
+
+    def __getitem__(self, key):
+        return self.segments[key]
+
+    def __setitem__(self, key, value):
+        raise TypeError("TrajectorySegmentContainer is immutable")
+
+    # intentionally do not support __mul__ & related
     
 
 class SingleTrajectoryAnalysis(object):

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -2,6 +2,24 @@ import openpathsampling as paths
 import numpy as np
 
 class TrajectorySegmentContainer(object):
+    """Container object to analyze lists of trajectories (or segments).
+
+    For the most part, this imitates a list. It supports most list behaviors
+    (addition, iteration, etc). However, as a list of lists, it contains a
+    few useful helpers. 
+
+    Parameters
+    ----------
+    dt : float
+        time step between frames in a segment
+
+    Attributes
+    ----------
+    n_frames : list of int
+        number of frames (length) of each segment in this container.
+    times : list of float
+        duration of each segment (length * self.dt) in this container.
+    """
     def __init__(self, segments, dt=None):
         self._segments = segments
         self.dt = dt
@@ -190,7 +208,7 @@ class SingleTrajectoryAnalysis(object):
 
         Returns
         -------
-        :class:`.TrajectorySegmentContainer`
+        list of :class:`.Trajectory`
             the frames from (and including) each first entry from `to_vol`
             into `from_vol` until (and including) the next entry into
             `to_vol`, with no frames in `forbidden`, and with frames removed
@@ -223,6 +241,12 @@ class SingleTrajectoryAnalysis(object):
         state : :class:`.Volume`
             state volume to characterize. Must be one of the states in the
             transition
+
+        Returns
+        -------
+        :class:`.TrajectorySegmentContainer`
+            lifetime from first entrance of `stateA` until first entrance of
+            `stateB`
         """
         other_state = list(set([self.stateA, self.stateB]) - set([state]))[0]
         segments = self.get_lifetime_segments(
@@ -243,6 +267,11 @@ class SingleTrajectoryAnalysis(object):
             initial state volume for the transition
         stateB : :class:`.Volume`
             final state volume for the transition
+
+        Returns
+        -------
+        :class:`.TrajectorySegmentContainer`
+            transitions from `stateA` to `stateB` within `trajectory`
         """
         # we define the transitions ensemble just in case the transition is,
         # e.g., fixed path length TPS. We want flexible path length ensemble
@@ -269,6 +298,14 @@ class SingleTrajectoryAnalysis(object):
         interface : :class:`.Volume` or None
             interface to calculate the flux through. If `None`, same as
             `state`
+        
+        Returns
+        -------
+        dict
+            key 'in' maps to :class:`.TrajectorySegmentContainer` of frames
+            marked "inside" the interface; 'out' maps to frames "outside"
+            the interface. The reciprocal of the sum of the mean of these
+            two is the flux through the interface.
         """
         other = list(set([self.stateA, self.stateB]) - set([state]))[0]
         if interface is None:

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -109,46 +109,33 @@ class SingleTrajectoryAnalysis(object):
 
     @property
     def continuous_frames(self):
-        return {k: np.array([len(seg) for seg in self.continuous_segments[k]])
+        return {k: self.continuous_segments[k].n_frames
                 for k in self.continuous_segments.keys()}
     
     @property
     def continuous_times(self):
-        if self.dt is None: # pragma: no cover
-            raise RuntimeError("No time delta set")
-            # TODO: this might become a logger.warn
-        continuous_frames = self.continuous_frames
-        return {k : continuous_frames[k]*self.dt 
-                for k in continuous_frames.keys()}
+        return {k: self.continuous_segments[k].times
+                for k in self.continuous_segments.keys()}
 
     @property
     def lifetime_frames(self):
-        return {k: np.array([len(seg) for seg in self.lifetime_segments[k]])
+        return {k: self.lifetime_segments[k].n_frames 
                 for k in self.lifetime_segments.keys()}
                              
     @property
     def lifetimes(self):
-        if self.dt is None: # pragma: no cover
-            raise RuntimeError("No time delta set")
-            # TODO: this might become a logger.warn; use dt=1 otherwise
-        lifetime_frames = self.lifetime_frames
-        return {k : lifetime_frames[k]*self.dt 
-                for k in lifetime_frames.keys()}
+        return {k: self.lifetime_segments[k].times
+                for k in self.lifetime_segments.keys()}
 
     @property
     def transition_duration_frames(self):
-        return {k: np.array([len(seg) for seg in self.transition_segments[k]])
+        return {k: self.transition_segments[k].n_frames
                 for k in self.transition_segments.keys()}
 
     @property
     def transition_duration(self):
-        if self.dt is None: # pragma: no cover
-            raise RuntimeError("No time delta set")
-            # TODO: this might become a logger.warn; use dt=1 otherwise
-        transition_duration_frames = self.transition_duration_frames
-        return {k : transition_duration_frames[k]*self.dt 
-                for k in transition_duration_frames.keys()}
-
+        return {k: self.transition_segments[k].times
+                for k in self.transition_segments.keys()}
 
     def analyze_continuous_time(self, trajectory, state):
         """Analysis to obtain continuous times for given state.

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -6,13 +6,26 @@ class TrajectorySegmentContainer(object):
         self.segments = segments
         self.dt = dt
 
-    def frames(self):
+    def n_frames(self):
         return np.array([len(seg) for seg in self.segments])
 
     def times(self):
+        if self.dt is None:
+            raise RuntimeError("No time delta set")
+            # TODO: this might become a logger.warn
         return np.array([len(seg)*self.dt for seg in self.segments])
 
-
+    def __add__(self, other):
+        if self.dt != other.dt:
+            raise RuntimeError(
+                "Different time steps in TrajectorySegmentContainers."
+            )
+        return TrajectorySegmentContainer(self.segments + other.segments,
+                                          self.dt)
+    
+    def __len__(self):
+        return len(self.segments)
+    
 
 class SingleTrajectoryAnalysis(object):
     """Analyze a trajectory or set of trajectories for transition properties.
@@ -51,12 +64,16 @@ class SingleTrajectoryAnalysis(object):
 
     def reset_analysis(self):
         """Reset the analysis by emptying all saved segments."""
-        self.continuous_segments = {self.stateA: [], self.stateB: []}
-        self.lifetime_segments = {self.stateA: [], self.stateB: []}
+        self.continuous_segments = {self.stateA: [], 
+                                    self.stateB: []}
+        self.lifetime_segments = {self.stateA: [], 
+                                  self.stateB: []}
         self.transition_segments = {(self.stateA, self.stateB): [], 
                                     (self.stateB, self.stateA): []}
-        self.flux_segments = {self.stateA: {'in': [], 'out': []},
-                              self.stateB: {'in': [], 'out': []}}
+        self.flux_segments = {self.stateA: {'in': [],
+                                            'out': []},
+                              self.stateB: {'in': [],
+                                            'out': []}}
 
     @property
     def continuous_frames(self):

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -1,6 +1,18 @@
 import openpathsampling as paths
 import numpy as np
 
+class TrajectorySegmentContainer(object):
+    def __init__(self, segments, dt=None):
+        self.segments = segments
+        self.dt = dt
+
+    def frames(self):
+        return np.array([len(seg) for seg in self.segments])
+
+    def times(self):
+        return np.array([len(seg)*self.dt for seg in self.segments])
+
+
 
 class SingleTrajectoryAnalysis(object):
     """Analyze a trajectory or set of trajectories for transition properties.

--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -8,43 +8,39 @@ class TrajectorySegmentContainer(object):
 
     @property
     def n_frames(self):
-        return np.array([len(seg) for seg in self.segments])
+        return np.array([len(seg) for seg in self._segments])
 
     @property
     def times(self):
         if self.dt is None:
             raise RuntimeError("No time delta set")
             # TODO: this might become a logger.warn
-        return np.array([len(seg)*self.dt for seg in self.segments])
-
-    @property
-    def segments(self):
-        # segments cannot be set
-        return self._segments
+        return np.array([len(seg)*self.dt for seg in self._segments])
 
     def __add__(self, other):
         if self.dt != other.dt:
             raise RuntimeError(
                 "Different time steps in TrajectorySegmentContainers."
             )
-        return TrajectorySegmentContainer(self.segments + other.segments,
+        return TrajectorySegmentContainer(self._segments + other._segments,
                                           self.dt)
 
     def __iadd__(self, other):
         # in this case, we ignore dt
-        self.segments += other.segments
+        self._segments += other._segments
+        return self
 
     def __len__(self):
-        return len(self.segments)
+        return len(self._segments)
 
     def __contains__(self, item):
-        return item in self.segments
+        return item in self._segments
 
     def __iter__(self):
-        return self.segments.__iter__()
+        return self._segments.__iter__()
 
     def __getitem__(self, key):
-        return self.segments[key]
+        return self._segments[key]
 
     def __setitem__(self, key, value):
         raise TypeError("TrajectorySegmentContainer is immutable")

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -12,6 +12,48 @@ logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
+class testTrajectorySegmentContainer(object):
+    def setup(self):
+        op = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])
+        vol1 = paths.CVRangeVolume(op, 0.1, 0.5)
+        vol3 = paths.CVRangeVolume(op, 2.0, 2.5)
+
+        self.trajectory = make_1d_traj(coordinates=[0.2, 0.3, 0.6, 2.1, 2.2,
+                                                    0.7, 0.4, 0.35, 2.4,
+                                                    0.33, 0.32, 0.31],
+                                       velocities=[0.0]*12)
+
+        all_in_1 = paths.AllInXEnsemble(vol1)
+        self.segments = all_in_1.split(self.trajectory)
+        self.container = paths.TrajectorySegmentContainer(self.segments,
+                                                          dt=0.5)
+
+    def test_list_behavior(self):
+        assert_equal(len(self.container), 3)
+        # len
+        # getters
+        # setters (should override this at some point)
+        # iterators, zip
+        raise SkipTest
+
+    def test_n_frames(self):
+        raise SkipTest
+
+    def test_times(self):
+        raise SkipTest
+
+    @raises(RuntimeError)
+    def test_times_without_dt(self):
+        raise SkipTest
+
+    def test_add(self):
+        raise SkipTest
+
+    @raises(RuntimeError)
+    def test_add_different_dt(self):
+        raise SkipTest
+        
+
 class testSingleTrajectoryAnalysis(object):
     def setup(self):
         op = paths.CV_Function("Id", lambda snap : snap.coordinates[0][0])

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -11,6 +11,7 @@ import numpy as np
 import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.storage').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
 
 class testTrajectorySegmentContainer(object):
@@ -201,10 +202,12 @@ class testSingleTrajectoryAnalysis(object):
         self.analyzer.reset_analysis()
         self.analyzer.analyze_flux(flux_traj, self.stateA, self.interfaceA0)
         flux_segs_A = self.analyzer.flux_segments[self.stateA]
-        assert_equal(flux_segs_A['in'], [flux_traj[5:8], flux_traj[13:14],
-                                         flux_traj[15:17], flux_traj[24:27]])
-        assert_equal(flux_segs_A['out'], [flux_traj[2:5], flux_traj[8:13],
-                                          flux_traj[14:15], flux_traj[27:29]])
+        assert_equal(flux_segs_A['in'][:], 
+                     [flux_traj[5:8], flux_traj[13:14], flux_traj[15:17],
+                      flux_traj[24:27]])
+        assert_equal(flux_segs_A['out'][:], 
+                     [flux_traj[2:5], flux_traj[8:13], flux_traj[14:15],
+                      flux_traj[27:29]])
 
     def test_analyze(self):
         # only test that it runs -- correctness testing in the others

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -6,6 +6,7 @@ from test_helpers import make_1d_traj
 import openpathsampling as paths
 
 import random
+import numpy as np
 
 import logging
 logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)
@@ -30,21 +31,36 @@ class testTrajectorySegmentContainer(object):
 
     def test_list_behavior(self):
         assert_equal(len(self.container), 3)
-        # len
-        # getters
-        # setters (should override this at some point)
-        # iterators, zip
+        assert_equal(self.container[0], self.segments[0])
+        for (truth, beauty) in zip(self.container, self.segments):
+            assert_equal(truth, beauty)
+        assert_equal(self.segments[0] in self.container, True)
+
+    @raises(AttributeError)
+    def test_segment_setter_fails(self):
+        self.container.segments = [self.trajectory]
+
+    @raises(TypeError)
+    def test_segments_setitem_fails(self):
+        self.container.segments[0] = self.trajectory
+        # TODO: I'd like to find a way to get this to error; for now we Skip
         raise SkipTest
+    
+    def test_segments(self):
+        assert_equal(self.container[0], self.trajectory[0:2])
+        assert_equal(self.container[1], self.trajectory[6:8])
+        assert_equal(self.container[2], self.trajectory[9:12])
 
     def test_n_frames(self):
-        raise SkipTest
+        assert_equal(self.container.n_frames.tolist(), [2, 2, 3])
 
     def test_times(self):
-        raise SkipTest
+        assert_equal(self.container.times.tolist(), [1.0, 1.0, 1.5])
 
     @raises(RuntimeError)
     def test_times_without_dt(self):
-        raise SkipTest
+        bad_container = paths.TrajectorySegmentContainer(self.segments)
+        bad_container.times
 
     def test_add(self):
         raise SkipTest

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -195,9 +195,24 @@ class testSingleTrajectoryAnalysis(object):
         self.analyzer.analyze(self.trajectory)
         cont_frames = self.analyzer.continuous_frames
         life_frames = self.analyzer.lifetime_frames
+        trans_frames = self.analyzer.transition_duration_frames
+        cont_times = self.analyzer.continuous_times
+        life_times = self.analyzer.lifetimes
+        trans_times = self.analyzer.transition_duration
+
         self.analyzer.reset_analysis()
         self.analyzer.analyze([self.trajectory])
         assert_equal(cont_frames[self.stateA].tolist(), 
                      self.analyzer.continuous_frames[self.stateA].tolist())
         assert_equal(life_frames[self.stateA].tolist(), 
                      self.analyzer.lifetime_frames[self.stateA].tolist())
+        A2B = (self.stateA, self.stateB)
+        assert_equal(trans_frames[A2B].tolist(),
+                     self.analyzer.transition_duration_frames[A2B].tolist())
+        assert_equal(cont_times[self.stateA].mean(),
+                     self.analyzer.continuous_times[self.stateA].mean())
+        assert_equal(life_times[self.stateA].mean(),
+                     self.analyzer.lifetimes[self.stateA].mean())
+        assert_equal(trans_times[A2B].mean(),
+                     self.analyzer.transition_duration[A2B].mean())
+

--- a/openpathsampling/tests/test_single_trajectory_analysis.py
+++ b/openpathsampling/tests/test_single_trajectory_analysis.py
@@ -122,54 +122,34 @@ class testSingleTrajectoryAnalysis(object):
                             velocities=[1.0]*len(sequence))
 
     def test_analyze_continuous_time(self):
-        self.analyzer.analyze_continuous_time(self.trajectory, self.stateA)
-        assert_equal(self.analyzer.continuous_frames[self.stateA].tolist(),
-                     [3, 1, 1, 1, 1, 1, 1])
-        self.analyzer.analyze_continuous_time(self.trajectory, self.stateB)
-        assert_equal(self.analyzer.continuous_frames[self.stateB].tolist(),
-                     [1, 1, 1, 5])
-        assert_almost_equal(self.analyzer.continuous_times[self.stateA].mean(),
-                            9.0/7.0*0.1)
-        assert_almost_equal(self.analyzer.continuous_times[self.stateB].mean(),
-                            8.0/4.0*0.1)
-
-    @raises(KeyError)
-    def test_analyze_continuous_time_bad_state(self):
-        self.analyzer.analyze_continuous_time(self.trajectory, self.stateX)
+        resultA = self.analyzer.analyze_continuous_time(self.trajectory, 
+                                                        self.stateA)
+        assert_equal(resultA.n_frames.tolist(), [3, 1, 1, 1, 1, 1, 1])
+        resultB = self.analyzer.analyze_continuous_time(self.trajectory,
+                                                        self.stateB)
+        assert_equal(resultB.n_frames.tolist(), [1, 1, 1, 5])
+        assert_almost_equal(resultA.times.mean(), 9.0/7.0*0.1)
+        assert_almost_equal(resultB.times.mean(), 8.0/4.0*0.1)
 
     def test_analyze_lifetime(self):
-        self.analyzer.analyze_lifetime(self.trajectory, self.stateA)
-        self.analyzer.analyze_lifetime(self.trajectory, self.stateB)
-        assert_equal(self.analyzer.lifetime_frames[self.stateA].tolist(),
-                     [3, 1, 2])  # A->B
-        assert_equal(self.analyzer.lifetime_frames[self.stateB].tolist(),
-                     [2, 1, 1, 11])  # B->A
-        assert_almost_equal(self.analyzer.lifetimes[self.stateA].mean(),
-                            6.0/3.0*0.1)
-        assert_almost_equal(self.analyzer.lifetimes[self.stateB].mean(),
-                            15.0/4.0*0.1)
+        resA = self.analyzer.analyze_lifetime(self.trajectory, self.stateA)
+        resB = self.analyzer.analyze_lifetime(self.trajectory, self.stateB)
+        assert_equal(resA.n_frames.tolist(), [3, 1, 2])  # A->B
+        assert_equal(resB.n_frames.tolist(), [2, 1, 1, 11])  # B->A
+        assert_almost_equal(resA.times.mean(), 6.0/3.0*0.1)
+        assert_almost_equal(resB.times.mean(), 15.0/4.0*0.1)
 
     def test_analyze_transition_duration(self):
-        self.analyzer.analyze_transition_duration(self.trajectory,
-                                                  self.stateA, self.stateB)
-        self.analyzer.analyze_transition_duration(self.trajectory,
-                                                  self.stateB, self.stateA)
-        assert_equal(
-            self.analyzer.transition_duration_frames[(self.stateA, 
-                                                      self.stateB)].tolist(),
-            [2, 0, 0, 1]
-        )
-        assert_equal(
-            self.analyzer.transition_duration_frames[(self.stateB, 
-                                                      self.stateA)].tolist(),
-            [1, 0, 0, 6]
-        )
-        assert_equal(self.analyzer.transition_duration[(self.stateA,
-                                                        self.stateB)].mean(),
-                     3.0/4.0*0.1)
-        assert_equal(self.analyzer.transition_duration[(self.stateB,
-                                                        self.stateA)].mean(),
-                     7.0/4.0*0.1)
+        resAB = self.analyzer.analyze_transition_duration(self.trajectory,
+                                                          self.stateA,
+                                                          self.stateB)
+        resBA = self.analyzer.analyze_transition_duration(self.trajectory,
+                                                          self.stateB,
+                                                          self.stateA)
+        assert_equal(resAB.n_frames.tolist(), [2, 0, 0, 1])
+        assert_equal(resBA.n_frames.tolist(), [1, 0, 0, 6])
+        assert_equal(resAB.times.mean(), 3.0/4.0*0.1)
+        assert_equal(resBA.times.mean(), 7.0/4.0*0.1)
 
     def test_analyze_flux(self):
         # A: [{out: 1, in: 1}
@@ -179,8 +159,8 @@ class testSingleTrajectoryAnalysis(object):
         # frame numbers       0    5    0    5    0
         # in (I) or out (O):   OIOIIIOOI   IIOO 
         core_traj = self._make_traj(flux_core_test_str)
-        self.analyzer.analyze_flux(core_traj, self.stateA)
-        flux_segs_A = self.analyzer.flux_segments[self.stateA]
+        flux_segs_A = self.analyzer.analyze_flux(core_traj, self.stateA)
+        # flux_segs_A = self.analyzer.flux_segments[self.stateA]
         assert_equal(len(flux_segs_A['in']), 4)
         assert_equal(flux_segs_A['in'][0], core_traj[2:3])
         assert_equal(flux_segs_A['in'][1], core_traj[4:7])
@@ -200,8 +180,9 @@ class testSingleTrajectoryAnalysis(object):
         assert_equal(len(flux_iface_traj_str), 31) # check I counted correctly
         flux_traj = self._make_traj(flux_iface_traj_str)
         self.analyzer.reset_analysis()
-        self.analyzer.analyze_flux(flux_traj, self.stateA, self.interfaceA0)
-        flux_segs_A = self.analyzer.flux_segments[self.stateA]
+        flux_segs_A = self.analyzer.analyze_flux(flux_traj, self.stateA,
+                                                 self.interfaceA0)
+        # flux_segs_A = self.analyzer.flux_segments[self.stateA]
         assert_equal(flux_segs_A['in'][:], 
                      [flux_traj[5:8], flux_traj[13:14], flux_traj[15:17],
                       flux_traj[24:27]])


### PR DESCRIPTION
Just a few more things to make `SingleTrajectoryAnalysis` easier to use in practice.

- [x] Create results object which has a few useful extra routines. Currently, we have a bunch of functions that variously return lists of trajectory segments, the lengths of those segments, or the time duration of those segments. All of this gets grouped into one class, although the old versions still work (they just call the specific class)
- [x] Switch from directly storing instance variables to returning the results (except for the `analyze` function, which runs everything). This makes it easier to use this stuff in interactive analysis.

Question: Renaming? Neither of the names of classes in `single_trajectory_analysis.py` are very good (`SingleTrajectoryAnalysis` and `TrajectorySegmentContainer`), but I don’t have any better names either. The functionality is definitely useful, though. 