### PR TITLE
Major performance improvements: Ensembles, Volumes, Splitting

### DIFF
--- a/openpathsampling/analysis/single_trajectory_analysis.py
+++ b/openpathsampling/analysis/single_trajectory_analysis.py
@@ -217,14 +217,14 @@ class SingleTrajectoryAnalysis(object):
         if forbidden is None:
             forbidden = paths.EmptyVolume()
         ensemble_BAB = paths.SequentialEnsemble([
-            paths.AllInXEnsemble(to_vol) & paths.LengthEnsemble(1),
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(to_vol),
             paths.PartInXEnsemble(from_vol) & paths.AllOutXEnsemble(to_vol),
-            paths.AllInXEnsemble(to_vol) & paths.LengthEnsemble(1)
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(to_vol)
         ]) & paths.AllOutXEnsemble(forbidden)
         ensemble_AB = paths.SequentialEnsemble([
-            paths.AllInXEnsemble(from_vol) & paths.LengthEnsemble(1),
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(from_vol),
             paths.OptionalEnsemble(paths.AllOutXEnsemble(to_vol)),
-            paths.AllInXEnsemble(to_vol) & paths.LengthEnsemble(1)
+            paths.LengthEnsemble(1) & paths.AllInXEnsemble(to_vol) 
         ])
         BAB_split = ensemble_BAB.split(trajectory)
         AB_split = [ensemble_AB.split(part)[0] for part in BAB_split]

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -687,12 +687,15 @@ class EnsembleCombination(Ensemble):
         if Ensemble.use_shortcircuit:
             a = self.ensemble1(trajectory, trusted)
             logger.debug("Combination is " + self.__class__.__name__)
-            logger.debug("Combination: " + self.ensemble1.__class__.__name__ + 
-                         " is "+str(a))
-            logger.debug("Combination: " + self.ensemble2.__class__.__name__ +
-                         " is " +str(self.ensemble2(trajectory, trusted)))
-            logger.debug("Combination: returning " + 
-                         str(self.fnc(a,self.ensemble2(trajectory,trusted))))
+            logger.debug("Combination: " + self.ensemble1.__class__.__name__
+                         + " is "+str(a))
+            if logger.isEnabledFor(logging.DEBUG):
+                ens2 = self.ensemble2(trajectory, trusted)
+                logger.debug("Combination: " +
+                             self.ensemble2.__class__.__name__ +
+                             " is " +str(ens2))
+                logger.debug("Combination: returning " +
+                             str(self.fnc(a,ens2)))
             res_true = self.fnc(a, True)
             res_false = self.fnc(a, False)
             if res_false == res_true:
@@ -730,12 +733,14 @@ class EnsembleCombination(Ensemble):
             logger.debug("Combination is " + self.__class__.__name__)
             logger.debug("Combination.can_append: " + 
                          self.ensemble1.__class__.__name__ + " is "+str(a))
-            logger.debug("Combination.can_append: " 
-                         + self.ensemble2.__class__.__name__ +
-                         " is " +
-                         str(self.ensemble2.can_append(trajectory, trusted)))
-            logger.debug("Combination.can_append: returning " + 
-                         str(self.fnc(a,self.ensemble2.can_append(trajectory,trusted))))
+            if logger.isEnabledFor(logging.DEBUG):
+                ens2_can_append = self.ensemble2.can_append(trajectory,
+                                                            trusted)
+                logger.debug("Combination.can_append: " 
+                             + self.ensemble2.__class__.__name__ +
+                             " is " + str(ens2_can_append))
+                logger.debug("Combination.can_append: returning " + 
+                             str(self.fnc( a, ens2_can_append)))
             res_true = self._continue_fnc(a, True)
             res_false = self._continue_fnc(a, False)
             if res_false == res_true:

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -324,6 +324,7 @@ class Ensemble(StorableNamedObject):
         min_length = max(1, min_length)
 
         logger.debug("Looking for subtrajectories in " + str(trajectory))
+        old_tt_len = 0
 
         if not reverse:
             start = 0
@@ -332,7 +333,15 @@ class Ensemble(StorableNamedObject):
             while start <= length - min_length and end <= length:
                 # print start, end
                 tt = trajectory[start:end]
-                if end < length and self.can_append(tt):
+
+                can_append_tt = False
+                if len(tt) != old_tt_len+1:
+                    can_append_tt = self.can_append(tt)
+                else:
+                    can_append_tt = self.can_append(tt, trusted=True)
+                old_tt_len = len(tt)
+
+                if end < length and can_append_tt:
                     end += 1
                     if end - start > max_length + 1:
                         start += 1

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -335,7 +335,7 @@ class Ensemble(StorableNamedObject):
                 tt = trajectory[start:end]
 
                 can_append_tt = False
-                if len(tt) != old_tt_len+1:
+                if len(tt) != old_tt_len + 1:
                     can_append_tt = self.can_append(tt)
                 else:
                     can_append_tt = self.can_append(tt, trusted=True)
@@ -372,7 +372,15 @@ class Ensemble(StorableNamedObject):
 
             while start >= 0 and end >= min_length:
                 tt = trajectory[start:end]
-                if start > 0 and self.can_prepend(tt):
+
+                can_prepend_tt = False
+                if len(tt) != old_tt_len + 1:
+                    can_prepend_tt = self.can_prepend(tt)
+                else:
+                    can_prepend_tt = self.can_prepend(tt, trusted=True)
+                old_tt_len = len(tt)
+
+                if start > 0 and can_prepend_tt:
                     start -= 1
                     if end - start > max_length + 1:
                         end -=1

--- a/openpathsampling/volume.py
+++ b/openpathsampling/volume.py
@@ -118,7 +118,17 @@ class VolumeCombination(Volume):
         self.sfnc = str_fnc
 
     def __call__(self, snapshot):
-        return self.fnc(self.volume1.__call__(snapshot), self.volume2.__call__(snapshot))
+        # short circuit following JHP's implementation in ensemble.py
+        a = self.volume1(snapshot)
+        res_true = self.fnc(a, True)
+        res_false = self.fnc(a, False)
+        if res_false == res_true:
+            return res_true
+        else:
+            b = self.volume2(snapshot)
+            return self.fnc(a, b)
+        #return self.fnc(self.volume1.__call__(snapshot),
+                        #self.volume2.__call__(snapshot))
     
     def __str__(self):
         return '(' + self.sfnc.format(str(self.volume1), str(self.volume2)) + ')'


### PR DESCRIPTION
Performance improvements. Five-fold speedup in the DNA analysis I was doing; probably less (but still significant) in our examples.

- [x] Move expensive debug logging into `logger.isEnabledFor(logging.DEBUG)` scopes
- [x] Add short-circuit logic to volumes
- [x] Fix problem that `.split` is using an algorithm that does not scale linearly (not using `trusted=True`)
- [x] Switch ensembles to be better for short-circuit (`Length` before `Volume`) in flux calculation

Timings (in order of my implementations, so these are cumulative improvements) to use `SingleTrajectoryAnalysis.analyze_flux()` on a DNA trajectory of 10k frames. Inexact, since I just ran the test once on my laptop, but when you see a calculation drop from ~5 minutes to ~1 minute, that’s well beyond the margin of error (even for my sample of $N=1$).

* Current `master` branch: `264.98s user 1.95s system 89% cpu 4:56.82 total`
* Rescope debugging: `127.29s user 1.64s system 89% cpu 2:24.61 total`
* Short-circuit volumes: `96.98s user 1.45s system 90% cpu 1:49.07 total`
* Fix split algorithm: `62.83s user 1.35s system 80% cpu 1:19.98 total`
* Fix short-circuit order in flux: `57.13s user 1.20s system 85% cpu 1:08.24 total`

Of course, getting such improvement from the short-circuit volumes requires defining your volumes to take the most advantage of short-circuit logic. But that was easy to do with this particular system.

There’s some room to improve `SequentialEnsemble.can_append`, especially in its use of `_find_subtraj_final`. This should give us a significant speed boost. I’ll do that at a later date.

Other notes for future speedups:
* Looks like calculating the unit cells (after loading trajectory) is one of the major bottlenecks for this (25% of the total time). But I think that is in MDTraj?
* `chaindict` is always going to be inner-loop stuff. It looks like a good target for cythonization -- it does a lot of python function calls deep in inner loops, and Cython can massively decrease the overhead cost of those function calls.
* There are a number of algorithmic speed-ups that can happen once we start including results from path ensemble theory. That should be after 1.0, though.