### PR TITLE
Details of MD5 failues in conda install

### DIFF
--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -13,6 +13,8 @@ MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICON
 wget https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
+    echo "Expected: $MINICONDA_MD5"
+    echo "Found: $(md5sum $MINICONDA | cut -d ' ' -f 1)"
     exit 1
 fi
 bash $MINICONDA -b

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -8,7 +8,7 @@ sudo apt-get update
 echo travis_fold:start:install.conda
 echo Install conda
 
-MINICONDA=Miniconda-latest-Linux-x86_64.sh
+MINICONDA=Miniconda2-latest-Linux-x86_64.sh
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then


### PR DESCRIPTION
Right now, miniconda's MD5 doesn't match the value that Travis is seeing. 

I suspect this is a bug on the part of the folks at conda. It fails for me with both [OPS](https://travis-ci.org/choderalab/openpathsampling/builds/119608319) and nightly build on [dynamiq-md](https://travis-ci.org/dynamiq-md/dynamiq_engine/builds/119605522), both failing again after re-running, so I assume this is a bug and not a fluke.

This PR just adds a little more information of "expected" and "found" after an MD5 mismatch in the miniconda setup. Potentially useful debug info that probably should make its way elsewhere.