### PR TITLE
RuntimeWarning that should be AttributeError in Trajectory

### DIFF
--- a/openpathsampling/engines/trajectory.py
+++ b/openpathsampling/engines/trajectory.py
@@ -194,7 +194,16 @@ class Trajectory(list, StorableObject):
                     return out
 
             else:
-                raise RuntimeWarning('Cannot access attribute "%s" from this type of snapshots')
+                std_msg = "'{0}' object has no attribute '{1}'"
+                snap_msg = "Cannot delegate to snapshots. "
+                snap_msg += "'{2}' has no attribute '{1}'"
+                spacer = "\n                "
+                msg = (std_msg + spacer + snap_msg).format(
+                    str(self.__class__.__name__), 
+                    item,
+                    snapshot_class.__name__
+                )
+                raise AttributeError(msg)
 
         else:
             return []


### PR DESCRIPTION
We currently have the following:

```python
trajectory.not_an_attribute
```

```pytb
---------------------------------------------------------------------------
RuntimeWarning                            Traceback (most recent call last)
<ipython-input-9-4a503b36e4ce> in <module>()
----> 1 traj.not_an_attribute

/Users/dwhs/Dropbox/msm-tis/openpathsampling/engines/trajectory.py in __getattr__(self, item)
    195 
    196             else:
--> 197                 raise RuntimeWarning('Cannot access attribute "%s" from this type of snapshots')
    198 
    199         else:

RuntimeWarning: Cannot access attribute "%s" from this type of snapshots
```

Problems with this:

1. Aside from the other issues (parts 2 and 3) this forgot to fill in the `%s`
2. This is confusing to the user, because it is trying to auto-apply `Snapshot` features to a `Trajectory`. But if I was looking for an attribute of a `Trajectory` and got this error, I wouldn’t know why it was talking about `Snapshot`s. (The first time I got this was when I mistyped `trajectory.summarize_by_volumes_str`: if I wasn’t familiar with the internals here, this message would have confused me.)
3. This should be an `AttributeError`, not a `RuntimeWarning`.  If I do this with a normal list:
```python
test = [1,2,3,4]
test.not_an_attribute
```
I get
```pytb
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-12e045042461> in <module>()
----> 1 test.not_an_attribute

AttributeError: 'list' object has no attribute ‘not_an_attribute’
```

***

This PR fixes those three problems. New output:

```pytb
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-9-c9e248afd106> in <module>()
----> 1 trajectory.not_an_attribute

/Users/dwhs/Dropbox/msm-tis/openpathsampling/engines/trajectory.py in __getattr__(self, item)
    204                     snapshot_class.__name__
    205                 )
--> 206                 raise AttributeError(msg)
    207 
    208         else:

AttributeError: 'Trajectory' object has no attribute 'not_an_attribute'
                Cannot delegate to snapshots. 'ToySnapshot' has no attribute 'not_an_attribute'
```

#### Remaining bug

Note that there is still a bug here, but I’m not sure how to fix it and keep the feature this function supposed to add. The bug is the following:

```python
>>> import openpathsampling as paths
>>> empty_traj = paths.Trajectory([])
>>> # next should raise AttributeError
>>> empty_traj.not_an_attribute
[]
```

Because you default to thinking that any unknown attribute must be a request for a snapshot feature, you assume that an unknown attribute given to an empty trajectory must desire an empty list in response. But sometimes that should be an `AttributeError`.