### PR TITLE
OneWayShootingMoveScheme

### DIFF
--- a/openpathsampling/__init__.py
+++ b/openpathsampling/__init__.py
@@ -1,4 +1,6 @@
-from analysis.move_scheme import MoveScheme, DefaultScheme, LockedMoveScheme
+from analysis.move_scheme import (
+    MoveScheme, DefaultScheme, LockedMoveScheme, OneWayShootingMoveScheme
+)
 from analysis.network import (
     MSTISNetwork, TransitionNetwork, MISTISNetwork, TPSNetwork
 )

--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -641,7 +641,7 @@ class OneWayShootingMoveScheme(MoveScheme):
     Useful for building on top of. Useful as default for TPS.
     """
     def __init__(self, network, selector=None, ensembles=None, engine=None):
-        super(OneWayShootingStrategy, self).__init__(network)
+        super(OneWayShootingMoveScheme, self).__init__(network)
         self.append(strategies.OneWayShootingStrategy(selector, ensembles))
         self.append(strategies.OrganizeByMoveGroupStrategy())
 

--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -632,3 +632,16 @@ class LockedMoveScheme(MoveScheme):
     @movers.setter
     def movers(self, vals):
         self._movers = vals
+
+
+class OneWayShootingMoveScheme(MoveScheme):
+    """
+    MoveScheme with only a OneWayShooting strategy.
+
+    Useful for building on top of. Useful as default for TPS.
+    """
+    def __init__(self, network, selector=None, ensembles=None, engine=None):
+        super(OneWayShootingStrategy, self).__init__(network)
+        self.append(strategies.OneWayShootingStrategy(selector, ensembles))
+        self.append(strategies.OrganizeByMoveGroupStrategy())
+


### PR DESCRIPTION
In a number of cases (TPS being a prime example) we frequently want to use only shooting moves. This PR create a `OneWayShootingMoveScheme` object which has the minimum necessary to do shooting.

Note that you can always add other move strategies to this, if you want. For example, if you wanted path reversal as well, you use the `.apply_strategy` function to add that. 

Basically, I’d think of it this way:

* `DefaultScheme` gives a full default for TIS calculations: RETIS, with minus, with path reversal, etc.
* `SRTISScheme` gives a full default for SRTIS: same as `Default`, but with single-replica moves (e.g., ensemble hops instead of replica exchange)
* `MoveScheme` is a completely blank slate that you need to add everything else to
* `OneWayShootingScheme` is added to provide the most common starting point (1-way shooting moves on each ensemble, with global organization according to the move type), that a user would want to build on.

This would also be the standard move scheme for TPS (we can always add a `ShiftingStrategy` if we need to later).

- [x] Draft `OneWayShootingMoveScheme`
- [x] Tests for `OneWayShootingMoveScheme`

The code is pretty simple; it basically just wraps some slightly more advanced functionality into an easy package for novices.