### PR TITLE
Better test for shooting

### DIFF
--- a/openpathsampling/engines/dynamics_engine.py
+++ b/openpathsampling/engines/dynamics_engine.py
@@ -82,7 +82,8 @@ class DynamicsEngine(StorableNamedObject):
         self._check_options(options)
 
         # as default set a newly generated engine as the default engine
-        self.set_as_default()
+        # self.set_as_default()
+        # REMOVED because this breaks the ability to have multiple engines
 
     def _check_options(self, options = None):
         """

--- a/openpathsampling/pathsimulator.py
+++ b/openpathsampling/pathsimulator.py
@@ -363,13 +363,15 @@ class FullBootstrapping(PathSimulator):
 
         self.transition_shooters = [
             paths.OneWayShootingMover(selector=paths.UniformSelector(), 
-                                      ensemble=ens) 
+                                      ensemble=ens,
+                                      engine=self.engine) 
             for ens in transition.ensembles
         ]
 
         self.extra_shooters = [
             paths.OneWayShootingMover(selector=paths.UniformSelector(), 
-                                      ensemble=ens) 
+                                      ensemble=ens,
+                                      engine=self.engine) 
             for ens in self.extra_ensembles
         ]
         self.snapshot = snapshot.copy()
@@ -569,7 +571,7 @@ class CommittorSimulation(PathSimulator):
                  initial_snapshots=None, direction=None):
         super(CommittorSimulation, self).__init__(storage)
         self.engine = engine
-        paths.EngineMover.engine = engine
+        paths.EngineMover.default_engine = engine
         self.states = states
         self.randomizer = randomizer
         try:

--- a/openpathsampling/tests/test_shooting_point_analysis.py
+++ b/openpathsampling/tests/test_shooting_point_analysis.py
@@ -131,6 +131,7 @@ class testShootingPointAnalysis(object):
         import os
         if os.path.isfile(self.filename):
             os.remove(self.filename)
+        paths.EngineMover.default_engine = None # set by Committor
 
     def test_shooting_point_analysis(self):
         assert_equal(len(self.analyzer), 2)

--- a/openpathsampling/tests/testpathmover.py
+++ b/openpathsampling/tests/testpathmover.py
@@ -222,7 +222,8 @@ class testBackwardShootMover(testShootingMover):
     def test_move_toy_engine(self):
         mover = BackwardShootMover(
             ensemble=self.tps,
-            selector=UniformSelector()
+            selector=UniformSelector(),
+            engine=self.toy_engine
         )
         change = mover.move(self.toy_samp)
         newsamp = self.toy_samp + change
@@ -470,7 +471,7 @@ class testRandomAllowedChoiceMover(object):
                                       -0.1, 0.2, 0.4, 0.6, 0.8,
                                      ])
         self.dyn.initialized = True
-        SampleMover.engine = self.dyn
+        # SampleMover.engine = self.dyn
         op = CV_Function("myid", f=lambda snap :
                              snap.coordinates[0][0])
         stateA = CVRangeVolume(op, -100, 0.0)
@@ -493,7 +494,8 @@ class testRandomAllowedChoiceMover(object):
                             ensemble=self.ens2)
 
         self.shooter = ForwardShootMover(selector=UniformSelector(),
-                                         ensemble=self.ens2)
+                                         ensemble=self.ens2,
+                                         engine=self.dyn)
         self.pathrev = PathReversalMover(ensemble=self.ens1)
 
         ens_dict = {self.ens1 : self.pathrev, self.ens2 : self.shooter}
@@ -944,13 +946,14 @@ class testMinusMover(object):
             # goes to other state:
             1.16, 1.26, 1.16, -0.16, 1.16, 1.26, 1.16
         ])
-        SampleMover.engine = self.dyn
+        # SampleMover.engine = self.dyn
         self.dyn.initialized = True
         self.innermost = paths.TISEnsemble(volA, volB, volX)
         self.minus = paths.MinusInterfaceEnsemble(volA, volX)
         self.mover = MinusMover(
             minus_ensemble=self.minus,
-            innermost_ensembles=self.innermost
+            innermost_ensembles=self.innermost,
+            engine=self.dyn
         )
         self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15] 
         self.list_innermost = [-0.11, 0.11, 0.31, 0.11, -0.12]
@@ -990,6 +993,7 @@ class testMinusMover(object):
         samples = change.results
         assert_equal(samples[0].ensemble(samples[0].trajectory), True)
         assert_equal(samples[0].ensemble, self.minus._segment_ensemble)
+        assert_equal(self.mover.engine, self.dyn)
         
 
     def test_successful_move(self):
@@ -1162,13 +1166,14 @@ class testSingleReplicaMinusMover(object):
             # goes to other state:
             1.16, 1.26, 1.16, -0.16, 1.16, 1.26, 1.16
         ])
-        SampleMover.engine = self.dyn
+        # SampleMover.engine = self.dyn
         self.dyn.initialized = True
         self.innermost = paths.TISEnsemble(volA, volB, volX)
         self.minus = paths.MinusInterfaceEnsemble(volA, volX)
         self.mover = SingleReplicaMinusMover(
             minus_ensemble=self.minus,
-            innermost_ensembles=self.innermost
+            innermost_ensembles=self.innermost,
+            engine=self.dyn
         )
         self.first_segment = [-0.1, 0.1, 0.3, 0.1, -0.15] 
         self.list_innermost = [-0.11, 0.11, 0.31, 0.11, -0.12]

--- a/openpathsampling/tests/testpathsimulator.py
+++ b/openpathsampling/tests/testpathsimulator.py
@@ -62,6 +62,7 @@ class testCommittorSimulation(object):
         import os
         if os.path.isfile(self.filename):
             os.remove(self.filename)
+        paths.EngineMover.default_engine = None
 
     def test_initialization(self):
         sim = self.simulation  # convenience

--- a/openpathsampling/tests/testshooting.py
+++ b/openpathsampling/tests/testshooting.py
@@ -18,7 +18,7 @@ class SelectorTest(object):
         self.dyn = CalvinistDynamics([-0.5, -0.4, -0.3, -0.2, -0.1,
                                       0.1, 0.2, 0.3, 0.4, 0.5])
                                       #0.5, 0.4, 0.3, 0.2, 0.1])
-        SampleMover.engine = self.dyn
+        # SampleMover.engine = self.dyn
         self.dyn.initialized = True
         self.ens = LengthEnsemble(5)
         self.gs = SampleSet(Sample(
@@ -37,7 +37,8 @@ class testFirstFrameSelector(SelectorTest):
     def test_shooting_move(self):
         self.shooter = ForwardShootMover(
             ensemble=self.ens,
-            selector=FirstFrameSelector()
+            selector=FirstFrameSelector(),
+            engine=self.dyn
         )
         change = self.shooter.move(self.gs)
         samples = change.trials
@@ -58,7 +59,8 @@ class testFinalFrameSelector(SelectorTest):
     def test_shooting_move(self):
         self.shooter = BackwardShootMover(
             ensemble=self.ens,
-            selector=FinalFrameSelector()
+            selector=FinalFrameSelector(),
+            engine=self.dyn
         )
         change = self.shooter.move(self.gs)
         samples = change.trials


### PR DESCRIPTION
Building off of ideas from the tests I wrote in #454, I’ve written tests for our shooting movers that should catch it if we ever regress on #416 (which relates to these “kinked” trajectories we were seeing when the reversal of the backwards shooting snapshot was done incorrectly.)

@jhprinz fixed the problem a while ago (#429 or, at worst, #445), but I didn’t want to close the issue until we had a more thorough test. This is that test.

Closes #416.

This also includes some fixes to actually allow multiple engines, following on #465. I removed the way engines made themselves default automatically on creation. The place to set the default engine is inside a `PathSimulator`, or directly by using `EngineMover.default_engine`. The implicit defaults were causing problems in tests that involved more than one engine.