### PR TITLE
Remove pin to mdtraj version 1.5.1

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pymbar
     - docopt
     - pyyaml
-    - mdtraj 1.5.1
+    - mdtraj
     - svgwrite
     - networkx
     - matplotlib


### PR DESCRIPTION
Most recent MDTraj release ([1.7.0](https://github.com/mdtraj/mdtraj/releases/tag/1.7.0)) should obviate the pin to 1.5.1. Thanks @jchodera for the heads up when https://github.com/mdtraj/mdtraj/pull/1089 got merged.

Resolves #436. (At least, assuming conda knows of that release and that it does fix the problems we had.)