### PR TITLE
Ensemble cache for frame-by-frame ensembles

### DIFF
--- a/devtools/ci/ipythontests.sh
+++ b/devtools/ci/ipythontests.sh
@@ -27,7 +27,7 @@ ipynbtest.py --strict "test_snapshot.ipynb" || testfail=1
 date
 ipynbtest.py "tutorial_storage.ipynb" || testfail=1
 date
-ipynbtest.py --strict "test_netcdfplus.ipynb" || testfail=1
+ipynbtest.py "test_netcdfplus.ipynb" || testfail=1
 date
 ipynbtest.py --strict "test_cv.ipynb" || testfail=1
 date

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1612,7 +1612,17 @@ class AllInXEnsemble(VolumeEnsemble):
         frame_num = -(cache.direction + 1) / 2  # 1 -> -1; -1 -> 0
         reset = cache.check(trajectory)
         if reset:
-            cache.contents['previous'] = None
+            if len(trajectory) < 2:
+                cache.contents['previous'] = None
+            else:
+                # NOTE: is it possible that we'd reset a cache more than
+                # once in a single trajectory? that could mean that this
+                # starts to scale quadratically
+                # I think a necessary condition for that to be a problem is
+                # that this ensemble shows up in both a Union and an
+                # Intersection ...
+                cache.contents['previous'] = self(trajectory[:-1],
+                                                  trusted=False)
         cached_val = cache.contents['previous']
         if cached_val == True or cached_val is None:
             # need to check this frame (no prev traj, or prev traj is True)
@@ -1666,7 +1676,7 @@ class AllOutXEnsemble(AllInXEnsemble):
     '''    
     @property
     def _volume(self):
-        return ~ self.volume
+        return ~self.volume
     
     def __str__(self):
         return 'x[t] in {0} for all t'.format(self._volume)

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1626,6 +1626,11 @@ class AllInXEnsemble(VolumeEnsemble):
     def __call__(self, trajectory, trusted=None):
         if len(trajectory) == 0:
             return False
+        # TODO: We might be able to speed this up based on can_append
+        # being the same as call for this ensemble. Something like check
+        # the can_append cache instead of/as well as the call cache. May
+        # still have problems with overshooting -- but this might provide a
+        # speed-up in sequential ensemble's checking phase
         if trusted == True and self._use_cache:
             return self._trusted_call(trajectory, self._cache_call)
         else:
@@ -1706,7 +1711,7 @@ class PartOutXEnsemble(PartInXEnsemble):
     @property
     def _volume(self):
         # effectively use PartInXEnsemble but with inverted volume
-        return ~ self.volume
+        return ~self.volume
 
     def __invert__(self):
         return AllInXEnsemble(self.volume, self.trusted)

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1640,6 +1640,7 @@ class AllInXEnsemble(VolumeEnsemble):
                 # would be to implement a more complicated cache.reset,
                 # which checks whether the previous traj was a subtraj of
                 # this one (other than one frame less). ~~~DWHS
+                reset_value = self(trajectory[:-1], trusted=False)
                 cache.contents['previous'] = self(trajectory[:-1],
                                                   trusted=False)
 
@@ -1656,8 +1657,9 @@ class AllInXEnsemble(VolumeEnsemble):
     def can_append(self, trajectory, trusted=False):
         if len(trajectory) == 0:
             return True
-        if trusted == True:
-            return self(trajectory[slice(len(trajectory)-1, None)], trusted)
+        elif trusted and self._use_cache:
+            return self._trusted_call(trajectory, self._cache_can_append)
+            #return self(trajectory[slice(len(trajectory)-1, None)], trusted)
         else:
             return self(trajectory)
 

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1585,10 +1585,8 @@ class VolumeEnsemble(Ensemble):
 
         self._use_cache = True
         self._cache_can_append = EnsembleCache(+1)
-        self._cache_strict_can_append = EnsembleCache(+1)
         self._cache_call = EnsembleCache(+1)
         self._cache_can_prepend = EnsembleCache(-1)
-        self._cache_strict_can_prepend = EnsembleCache(-1)
         self._cache_check_reverse = EnsembleCache(-1)
 
 
@@ -1670,9 +1668,8 @@ class AllInXEnsemble(VolumeEnsemble):
     def can_prepend(self, trajectory, trusted=False):
         if len(trajectory) == 0:
             return True
-        if trusted == True:
+        if trusted and self._use_cache:
             return self._trusted_call(trajectory, self._cache_can_prepend)
-            #return self(trajectory[slice(0,1)], trusted)
         else:
             return self(trajectory)
 
@@ -1696,10 +1693,11 @@ class AllInXEnsemble(VolumeEnsemble):
 
     def check_reverse(self, trajectory, trusted=False):
         # order in this one only matters if it is trusted
-        if trusted:
+        if trusted and self._use_cache:
             #print "Rev Trusted"
-            frame = trajectory.get_as_proxy(0)
-            return self._volume(frame)
+            return self._trusted_call(trajectory, self._cache_check_reverse)
+            #frame = trajectory.get_as_proxy(0)
+            #return self._volume(frame)
         else:
             #print "Rev UnTrusted"
             return self(trajectory) # in this case, order wouldn't matter

--- a/openpathsampling/ensemble.py
+++ b/openpathsampling/ensemble.py
@@ -1640,9 +1640,14 @@ class AllInXEnsemble(VolumeEnsemble):
                 # would be to implement a more complicated cache.reset,
                 # which checks whether the previous traj was a subtraj of
                 # this one (other than one frame less). ~~~DWHS
-                reset_value = self(trajectory[:-1], trusted=False)
-                cache.contents['previous'] = self(trajectory[:-1],
-                                                  trusted=False)
+                if frame_num == -1:
+                    reset_value = self(trajectory[:-1], trusted=False)
+                elif frame_num == 0:
+                    reset_value = self(trajectory[1:], trusted=False)
+                else:  # pragma: no cover
+                    raise RuntimeError("Bad value for frame_num: " +
+                                       str(frame_num))
+                cache.contents['previous'] = reset_value
 
         cached_val = cache.contents['previous']
         if cached_val == True or cached_val is None:
@@ -1659,7 +1664,6 @@ class AllInXEnsemble(VolumeEnsemble):
             return True
         elif trusted and self._use_cache:
             return self._trusted_call(trajectory, self._cache_can_append)
-            #return self(trajectory[slice(len(trajectory)-1, None)], trusted)
         else:
             return self(trajectory)
 
@@ -1667,7 +1671,8 @@ class AllInXEnsemble(VolumeEnsemble):
         if len(trajectory) == 0:
             return True
         if trusted == True:
-            return self(trajectory[slice(0,1)], trusted)
+            return self._trusted_call(trajectory, self._cache_can_prepend)
+            #return self(trajectory[slice(0,1)], trusted)
         else:
             return self(trajectory)
 

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2436,8 +2436,8 @@ class testVolumeCombinations(EnsembleTest):
         self.outA_and_outB = self.outA & self.outB
         self.partinA_or_partinB = self.partinA | self.partinB
         self.partinA_and_partinB = self.partinA & self.partinB
-        extras = build_trajdict(['babbc', 'ca', 'bcbba', 'abbc', 'cbba'], 
-                                lower, upper)
+        extras = build_trajdict(['babbc', 'ca', 'bcbba', 'abbc', 'cbba',
+                                 'abbcb', 'cbbab'], lower, upper)
         for test in extras.keys():
             extras[test] = make_1d_traj(coordinates=extras[test],
                                        velocities=[1.0]*len(extras[test]))
@@ -2634,7 +2634,26 @@ class testVolumeCombinations(EnsembleTest):
         )
 
     def test_can_prepend_outA_and_outB(self):
-        raise SkipTest
+        self._test_trusted(
+            trajectory=self.local_ttraj['upper_in_out_out_cross_out'],
+            function=self.outA_and_outB.can_prepend,
+            results=[True, False, False, False, False],
+            cache_results={
+                self.outA._cache_can_prepend : [True, True, True, True, False],
+                self.outB._cache_can_prepend : [True, False, False, False, False]
+            },
+            direction=-1
+        )
+        self._test_trusted(
+            trajectory=self.local_ttraj['upper_cross_out_out_in_out'],
+            function=self.outA_and_outB.can_prepend,
+            results=[True, False, False, False, False],
+            cache_results={
+                self.outA._cache_can_prepend : [True, False, False, False, False],
+                self.outB._cache_can_prepend : [True, None, None, None, None]
+            },
+            direction=-1
+        )
 
 
 class testAbstract(object):

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2512,7 +2512,6 @@ class testVolumeCombinations(EnsembleTest):
         )
 
     def test_call_outA_and_outB(self):
-        raise SkipTest
         self._test_trusted_fwd(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
             function=self.outA_and_outB,
@@ -2524,15 +2523,15 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_call : [True, None, None, None, None]
             }
         )
-        #self._test_trusted_fwd(
-            #trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
-            #function=self.outA_or_outB,
-            #results=[True, False, False, False, False],
-            ##cache_results={
-                #self.outA._cache_call : [True, True, True, True, False],
-                #self.outB._cache_call : [True, False, False, False, None]
-            #}
-        #)
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
+            function=self.outA_and_outB,
+            results=[True, False, False, False, False],
+            cache_results={
+                self.outA._cache_call : [True, True, True, True, False],
+                self.outB._cache_call : [True, False, False, False, None]
+            }
+        )
 
     def test_call_partinA_or_partinB(self):
         raise SkipTest

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -1422,8 +1422,6 @@ class testSequentialEnsembleCache(EnsembleCacheTest):
         assert_equal(ens.can_append(traj[0:4]), True)
         assert_equal(ens.can_append(traj[0:5]), True)
         assert_equal(ens.can_append(traj[0:6]), True)
-        
-
 
     def test_sequential_caching_can_append(self):
         cache = self.pseudo_minus._cache_can_append
@@ -2423,6 +2421,49 @@ class testEnsembleSplit(EnsembleTest):
 
         sub_traj = ensembleAXA.find_last_subtrajectory(traj3)
         assert(traj3.subtrajectory_indices(sub_traj) == [2,3,4])
+
+class testUnionEnsemble(EnsembleTest):
+    def setup(self):
+        self.outA_or_outB = (paths.AllOutXEnsemble(vol1) |
+                             paths.AllOutXEnsemble(~vol2))
+        OAOOB = build_trajdict(['babbc'], lower, upper)
+        for test in OAOOB.keys():
+            OAOOB[test] = make_1d_traj(coordinates=OAOOB[test],
+                                       velocities=[1.0]*len(OAOOB[test]))
+        self.local_ttraj = dict(ttraj)
+        self.local_ttraj.update(OAOOB)
+
+    def test_call(self):
+        out_out_results = {
+            'upper_out' : True,
+            'upper_out_in' : True,
+            'upper_out_in_out' : True,
+            'upper_out_in_out_out' : True,
+            'upper_out_in_out_out_cross' : False
+        }
+        for test in out_out_results.keys():
+            failmsg = "Failure in "+test+"("+str(self.local_ttraj[test])+"): "
+            self._single_test(self.outA_or_outB, self.local_ttraj[test], 
+                              out_out_results[test], failmsg)
+
+            traj = self.local_ttraj['upper_out_in_out_out_cross']
+            assert_equal(self.outA_or_outB(traj[0:1], trusted=True), True)
+            assert_equal(self.outA_or_outB(traj[0:2], trusted=True), True)
+            assert_equal(self.outA_or_outB(traj[0:3], trusted=True), True)
+            assert_equal(self.outA_or_outB(traj[0:4], trusted=True), True)
+            #assert_equal(self.outA_or_outB(traj, trusted=True), False)
+
+
+
+
+    def test_can_append(self):
+        pass
+
+    def test_can_prepend(self):
+        pass
+
+class testIntersectionEnsemble(object):
+    pass
 
 class testAbstract(object):
     @raises_with_message_like(TypeError, "Can't instantiate abstract class")

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2469,7 +2469,12 @@ class testVolumeCombinations(EnsembleTest):
                 # cache_results could {cache : {'content_key' : [values]}}
                 if cache_results[cache][i] is not None:
                     #print "cache", cache_results.keys().index(cache),
-                    #print cache.contents['previous'], cache_results[cache][i]
+                    try:
+                        contents = cache.contents['previous'],
+                    except KeyError:
+                        contents = None
+                    #print contents, cache_results[cache][i]
+
                     assert_equal(cache.contents['previous'],
                                  cache_results[cache][i])
 
@@ -2540,51 +2545,69 @@ class testVolumeCombinations(EnsembleTest):
         raise SkipTest
 
     def test_can_append_outA_or_outB(self):
-        raise SkipTest
-
-    def test_can_append_partinA_or_partinB(self):
-        raise SkipTest
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
+            function=self.outA_or_outB.can_append, 
+            results=[True, True, True, True, False], 
+            cache_results={
+                self.outA._cache_can_append : [True, False, False, False, False],
+                self.outB._cache_can_append : [None, True, True, True, False]
+            }
+        )
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
+            function=self.outA_or_outB.can_append,
+            results=[True, True, True, True, False],
+            cache_results={
+                self.outA._cache_can_append : [True, True, True, True, False],
+                self.outB._cache_can_append : [None, None, None, None, False]
+            }
+        )
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_in_cross'],
+            function=self.outA_or_outB.can_append,
+            results=[True, False],
+            cache_results={
+                self.outA._cache_can_append : [False, False],
+                self.outB._cache_can_append : [True, False]
+            }
+        )
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_cross_in'],
+            function=self.outA_or_outB.can_append,
+            results=[True, False],
+            cache_results={
+                self.outA._cache_can_append : [True, False],
+                self.outB._cache_can_append : [None, False]
+            }
+        )
 
     def test_can_append_outA_and_outB(self):
-        raise SkipTest
-
-    def test_can_append_partinA_and_partinB(self):
-        raise SkipTest
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
+            function=self.outA_and_outB.can_append,
+            results=[True, False, False, False, False],
+            cache_results={
+                # cache for A gets checked first: value of cache for B
+                # doesn't matter once cache for A is False (short-circuit)
+                self.outA._cache_can_append : [True, False, False, False, False],
+                self.outB._cache_can_append : [True, None, None, None, None]
+            }
+        )
+        self._test_trusted_fwd(
+            trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
+            function=self.outA_and_outB.can_append,
+            results=[True, False, False, False, False],
+            cache_results={
+                self.outA._cache_can_append : [True, True, True, True, False],
+                self.outB._cache_can_append : [True, False, False, False, None]
+            }
+        )
 
     def test_can_prepend_outA_or_outB(self):
         raise SkipTest
 
-    def test_can_prepend_partinA_or_partinB(self):
-        raise SkipTest
-
     def test_can_prepend_outA_and_outB(self):
-        raise SkipTest
-
-    def test_can_prepend_partinA_and_partinB(self):
-        raise SkipTest
-
-    def test_strict_can_append_outA_or_outB(self):
-        raise SkipTest
-
-    def test_strict_can_append_partinA_or_partinB(self):
-        raise SkipTest
-
-    def test_strict_can_append_outA_and_outB(self):
-        raise SkipTest
-
-    def test_strict_can_append_partinA_and_partinB(self):
-        raise SkipTest
-
-    def test_strict_can_prepend_outA_or_outB(self):
-        raise SkipTest
-
-    def test_strict_can_prepend_partinA_or_partinB(self):
-        raise SkipTest
-
-    def test_strict_can_prepend_outA_and_outB(self):
-        raise SkipTest
-
-    def test_strict_can_prepend_partinA_and_partinB(self):
         raise SkipTest
 
 

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2450,7 +2450,7 @@ class testUnionEnsemble(EnsembleTest):
         traj = self.local_ttraj['upper_out_in_out_out_cross']
         assert_equal(self.outA_or_outB(traj[0:1], trusted=True), True)
         assert_equal(self.outA._cache_call.contents['previous'], True)
-        assert_equal(self.outB._cache_call.contents['previous'], True)
+        # cache for B might not have been made yet: we can skip it
 
         assert_equal(self.outA_or_outB(traj[0:2], trusted=True), True)
         assert_equal(self.outA._cache_call.contents['previous'], False)

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2451,10 +2451,7 @@ class testUnionEnsemble(EnsembleTest):
             assert_equal(self.outA_or_outB(traj[0:2], trusted=True), True)
             assert_equal(self.outA_or_outB(traj[0:3], trusted=True), True)
             assert_equal(self.outA_or_outB(traj[0:4], trusted=True), True)
-            #assert_equal(self.outA_or_outB(traj, trusted=True), False)
-
-
-
+            assert_equal(self.outA_or_outB(traj, trusted=True), False)
 
     def test_can_append(self):
         pass

--- a/openpathsampling/tests/testensemble.py
+++ b/openpathsampling/tests/testensemble.py
@@ -2436,15 +2436,16 @@ class testVolumeCombinations(EnsembleTest):
         self.outA_and_outB = self.outA & self.outB
         self.partinA_or_partinB = self.partinA | self.partinB
         self.partinA_and_partinB = self.partinA & self.partinB
-        extras = build_trajdict(['babbc', 'ca', 'bcbba'], lower, upper)
+        extras = build_trajdict(['babbc', 'ca', 'bcbba', 'abbc', 'cbba'], 
+                                lower, upper)
         for test in extras.keys():
             extras[test] = make_1d_traj(coordinates=extras[test],
                                        velocities=[1.0]*len(extras[test]))
         self.local_ttraj = dict(ttraj)
         self.local_ttraj.update(extras)
 
-    def _test_trusted_fwd(self, trajectory, function, results,
-                          cache_results=None):
+    def _test_trusted(self, trajectory, function, results,
+                      cache_results=None, direction=+1):
         # Tests `trajectory` frame by frame in a forward direction for the
         # `function`, expecting `results`. Additionally, can take the 
 
@@ -2456,10 +2457,16 @@ class testVolumeCombinations(EnsembleTest):
             cache.__init__(direction=cache.direction)
 
         for i in range(len(trajectory)):
+            if direction > 0:
+                start = 0
+                end = i+1
+            elif direction < 0:
+                start = len(trajectory)-i-1
+                end = len(trajectory)
             # test untrusted
-            assert_equal(function(trajectory[0:i+1]), results[i])
+            assert_equal(function(trajectory[start:end]), results[i])
             # test trusted
-            trusted_val = function(trajectory[0:i+1], trusted=True)
+            trusted_val = function(trajectory[start:end], trusted=True)
             #print i, trusted_val, results[i]
             assert_equal(trusted_val, results[i])
             for cache in cache_results.keys():
@@ -2470,7 +2477,7 @@ class testVolumeCombinations(EnsembleTest):
                 if cache_results[cache][i] is not None:
                     #print "cache", cache_results.keys().index(cache),
                     try:
-                        contents = cache.contents['previous'],
+                        contents = cache.contents['previous']
                     except KeyError:
                         contents = None
                     #print contents, cache_results[cache][i]
@@ -2479,7 +2486,7 @@ class testVolumeCombinations(EnsembleTest):
                                  cache_results[cache][i])
 
     def test_call_outA_or_outB(self):
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
             function=self.outA_or_outB, 
             results=[True, True, True, True, False], 
@@ -2488,7 +2495,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_call : [None, True, True, True, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
             function=self.outA_or_outB,
             results=[True, True, True, True, False],
@@ -2497,7 +2504,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_call : [None, None, None, None, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_in_cross'],
             function=self.outA_or_outB,
             results=[True, False],
@@ -2506,7 +2513,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_call : [True, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_cross_in'],
             function=self.outA_or_outB,
             results=[True, False],
@@ -2517,7 +2524,7 @@ class testVolumeCombinations(EnsembleTest):
         )
 
     def test_call_outA_and_outB(self):
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
             function=self.outA_and_outB,
             results=[True, False, False, False, False],
@@ -2528,7 +2535,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_call : [True, None, None, None, None]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
             function=self.outA_and_outB,
             results=[True, False, False, False, False],
@@ -2545,7 +2552,7 @@ class testVolumeCombinations(EnsembleTest):
         raise SkipTest
 
     def test_can_append_outA_or_outB(self):
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
             function=self.outA_or_outB.can_append, 
             results=[True, True, True, True, False], 
@@ -2554,7 +2561,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_can_append : [None, True, True, True, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
             function=self.outA_or_outB.can_append,
             results=[True, True, True, True, False],
@@ -2563,7 +2570,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_can_append : [None, None, None, None, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_in_cross'],
             function=self.outA_or_outB.can_append,
             results=[True, False],
@@ -2572,7 +2579,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_can_append : [True, False]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_cross_in'],
             function=self.outA_or_outB.can_append,
             results=[True, False],
@@ -2583,7 +2590,7 @@ class testVolumeCombinations(EnsembleTest):
         )
 
     def test_can_append_outA_and_outB(self):
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_in_out_out_cross'],
             function=self.outA_and_outB.can_append,
             results=[True, False, False, False, False],
@@ -2594,7 +2601,7 @@ class testVolumeCombinations(EnsembleTest):
                 self.outB._cache_can_append : [True, None, None, None, None]
             }
         )
-        self._test_trusted_fwd(
+        self._test_trusted(
             trajectory=self.local_ttraj['upper_out_cross_out_out_in'],
             function=self.outA_and_outB.can_append,
             results=[True, False, False, False, False],
@@ -2605,7 +2612,26 @@ class testVolumeCombinations(EnsembleTest):
         )
 
     def test_can_prepend_outA_or_outB(self):
-        raise SkipTest
+        self._test_trusted(
+            trajectory=self.local_ttraj['upper_in_out_out_cross'],
+            function=self.outA_or_outB.can_prepend,
+            results=[True, True, True, False],
+            cache_results={
+                self.outA._cache_can_prepend : [True, True, True, False],
+                self.outB._cache_can_prepend : [None, None, None, False]
+            },
+            direction=-1
+        )
+        self._test_trusted(
+            trajectory=self.local_ttraj['upper_cross_out_out_in'],
+            function=self.outA_or_outB.can_prepend,
+            results=[True, True, True, False],
+            cache_results={
+                self.outA._cache_can_prepend : [False, False, False, False],
+                self.outB._cache_can_prepend : [True, True, True, False]
+            },
+            direction=-1
+        )
 
     def test_can_prepend_outA_and_outB(self):
         raise SkipTest


### PR DESCRIPTION
This will fix a significant bug in the ensemble code. This boils down to the statement that ensembles should act on trajectories, not on frames. To explain the problem, let's start with some terminology:

***Definition*** *(frame-by-frame ensemble)*: If a trajectory $(x_0, …, x_L)$ is in a *frame-by-frame* ensemble, then all you need is to look at is $x_{L+1}$ to know whether $(x_0, …, x_{L+1})$ is in the ensemble.

For example, consider `AllOutXEnsemble(stateA)`. If we know the value for the previous trajectory, we only need to look at the next frame, without considering the whole trajectory. If all frames $x_i$ with $i<=L$ were outside the state, and frame $x_{L+1}$ is outside the state, then obviously all frames with $i<=L+1$ are outside the state.

However, this is **not** true for combinations of frame-by-frame ensembles. This is the bug that this PR will fix. For example, consider `AllOutXEnsemble(stateA) | AllOutXEnsemble(stateB)`, and consider a trajectory `0A00B`, where `A` indicates a frame in `stateA`, `B` indicates a frame in `stateB`, and `0` indicates a frame in neither.

While the subtrajectory `0A00` is in `AllOut(B)` (and therefore `AllOut(A) | AllOut(B)`) and the subtrajectory `00B` is in `AllOut(A)`, the full trajectory is in neither `AllOut(A)` nor `AllOut(B)`, and therefore is not in their union, `AllOut(A) | AllOut(B)`.

The current code fails this test if built during a trajectory using `trusted=True`, which essentially tries to take a frame-by-frame approach to the trajectory. (Note: if not using `trusted=True`, our code gets the right answer -- but then building a trajectory scales quadratically with the length of the trajectory instead of linearly.) With `trusted=True`, the code assumes that the combination of frame-by-frame ensembles is also frame-by-frame. But a combination of frame-by-frame ensembles is not necessarily frame-by-frame. In the `0A00B` trajectory, each frame individually is in `AllOut(A) | AllOut(B)` -- again, this goes back to my old mantra that "ensembles are about trajectories, not frames."

The approach I’m using to fix this is to assign a cache to every frame-by-frame ensemble. Assuming it is still using the same trajectory (we already have ensemble cache to check that), we will cache the result of the previous subtrajectory. Our frame-by-frame ensembles have a behavior similar to the poisoned frame in PET: for some, once they are false they are always false (`AllIn`, `AllOut`) and for others, once they are true they are always true (`PartIn`, `PartOut`). This means that if we cache a result for trajectory $(x_0, …, x_L)$, we can combine that with a result based on only the frame $(x_{L+1})$ to get a result for the whole trajectory $(x_0, .., x_{L+1})$. For the `All*` ensembles, the combination is a logical `and`. For the `Part*` ensembles, it is a logical `or`.

In either case, the combination should then return the correct result. Consider the following, where each column corresponds to a frame, and the rows tell you what various ensembles should give as you build the trajectory from leftmost column to rightmost:

```
     traj 0A00B
  AllOutA TFFFF
  AllOutB TTTTF
    Union TTTTF
Intersect TFFFF
  Current TTTTT (union; trusted=True)
```

The caches of `AllOutA` and `AllOutB` should give the values above once the current frame has been evaluated.

- [x] Draft initial test to reproduce problem
- [x] Add support for ensemble cache to AllInX/AllOutX `__call__`
- [x] More complete tests for AllInX/AllOutX `__call__`
- [x] Support/tests for AllInX/AllOutX `can_*` methods
- [x] Fill in coverage gaps
