### PR TITLE
Add `allow_self_transitions` to `TPSNetwork`

### DIFF
--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -82,6 +82,8 @@ class GeneralizedTPSNetwork(TransitionNetwork):
         acceptable initial states
     final_states : list of :class:`.Volume`
         acceptable final states
+    allow_self_transitions : bool
+        whether self-transitions (A->A) are allowed; default is False
 
     Attributes
     ----------

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -194,8 +194,10 @@ class GeneralizedTPSNetwork(TransitionNetwork):
 
 
     @classmethod
-    def from_states_all_to_all(cls, states, **kwargs):
-        return cls(states, states, **kwargs)
+    def from_states_all_to_all(cls, states, allow_self_transitions=False,
+                               **kwargs):
+        return cls(states, states,
+                   allow_self_transitions=allow_self_transitions, **kwargs)
 
 
 class TPSNetwork(GeneralizedTPSNetwork):
@@ -205,16 +207,20 @@ class TPSNetwork(GeneralizedTPSNetwork):
     TransitionType = paths.TPSTransition
     # we implement these functions entirely to fix the signature (super's
     # version allow arbitrary kwargs) so the documentation can read them.
-    def __init__(self, initial_states, final_states):
-        super(TPSNetwork, self).__init__(initial_states, final_states)
+    def __init__(self, initial_states, final_states,
+                 allow_self_transitions=False):
+        super(TPSNetwork, self).__init__(initial_states, final_states,
+                                         allow_self_transitions)
 
     @classmethod
-    def from_state_pairs(cls, state_pairs):
+    def from_state_pairs(cls, state_pairs, allow_self_transitions=False):
         return super(TPSNetwork, cls).from_state_pairs(state_pairs)
 
     @classmethod
-    def from_states_all_to_all(cls, states):
-        return super(TPSNetwork, cls).from_states_all_to_all(states)
+    def from_states_all_to_all(cls, states, allow_self_transitions=False):
+        return super(TPSNetwork, cls).from_states_all_to_all(
+            states, allow_self_transitions
+        )
 
 
 class FixedLengthTPSNetwork(GeneralizedTPSNetwork):
@@ -226,10 +232,12 @@ class FixedLengthTPSNetwork(GeneralizedTPSNetwork):
     # However, without them, we need to explicitly name `length` as
     # length=value in these functions. This frees us of that, and gives us
     # clearer documentation.
-    def __init__(self, initial_states, final_states, length):
-        super(FixedLengthTPSNetwork, self).__init__(initial_states,
-                                                    final_states,
-                                                    length=length)
+    def __init__(self, initial_states, final_states, length,
+                 allow_self_transitions=False):
+        super(FixedLengthTPSNetwork, self).__init__(
+            initial_states, final_states,
+            allow_self_transitions=allow_self_transitions, length=length
+        )
 
     @classmethod
     def from_state_pairs(cls, state_pairs, length):
@@ -238,9 +246,12 @@ class FixedLengthTPSNetwork(GeneralizedTPSNetwork):
         )
 
     @classmethod
-    def from_states_all_to_all(cls, states, length):
+    def from_states_all_to_all(cls, states, length,
+                               allow_self_transitions=False):
         return super(FixedLengthTPSNetwork, cls).from_states_all_to_all(
-            states, length=length
+            states=states,
+            allow_self_transitions=allow_self_transitions,
+            length=length
         )
 
 

--- a/openpathsampling/analysis/network.py
+++ b/openpathsampling/analysis/network.py
@@ -109,9 +109,10 @@ class GeneralizedTPSNetwork(TransitionNetwork):
         self.final_states = final_states
 
         all_initial = paths.join_volumes(initial_states)
-        all_initial.name = "|".join([v.name for v in initial_states])
+        if len(initial_states) > 1:
+            all_initial.name = "|".join([v.name for v in initial_states])
 
-        if set(initial_states) == set(final_states):
+        if set(initial_states) == set(final_states) or len(final_states) == 1:
             all_final = all_initial
         else:
             all_final = paths.join_volumes(final_states)
@@ -122,7 +123,8 @@ class GeneralizedTPSNetwork(TransitionNetwork):
             my_final_states = [final for final in final_states
                                if my_initial != final or allow_self_transitions]
             my_final = paths.join_volumes(my_final_states)
-            my_final.name = "|".join([v.name for v in my_final_states])
+            if len(my_final_states) > 1:
+                my_final.name = "|".join([v.name for v in my_final_states])
             if  len(self._sampling_transitions) == 0:
                 self._sampling_transitions = [
                     self.TransitionType(my_initial, my_final, **kwargs)

--- a/openpathsampling/analysis/tis_analysis.py
+++ b/openpathsampling/analysis/tis_analysis.py
@@ -100,8 +100,8 @@ class TPSTransition(Transition):
             paths.AllInXEnsemble(stateB) & paths.LengthEnsemble(1)
         ])
 
-    def add_transition(self, stateA, stateB):
-        new_ens = self._tps_ensemble(stateA, stateB)
+    def add_transition(self, stateA, stateB, **kwargs):
+        new_ens = self._tps_ensemble(stateA, stateB, **kwargs)
         try:
             self.ensembles[0] = self.ensembles[0] | new_ens
         except AttributeError:

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -310,7 +310,18 @@ class testFixedLengthTPSNetwork(testTPSNetwork):
             assert_equal(network.transitions.values()[0].length, 10)
 
     def test_allow_self_transitions_false(self):
-        raise SkipTest
+        network = FixedLengthTPSNetwork.from_states_all_to_all(
+            self.states, allow_self_transitions=False, length=4
+        )
+        assert_equal(len(network.sampling_ensembles), 1)
+        ensemble = network.sampling_ensembles[0]
+        assert_equal(ensemble(self.traj['AA']), False)
+        assert_equal(ensemble(self.traj['AB']), True)
+        assert_equal(ensemble(self.traj['BA']), True)
+        assert_equal(ensemble(self.traj['BC']), True)
+        assert_equal(ensemble(self.traj['CA']), True)
+        assert_equal(ensemble(self.traj['BB']), False)
+        assert_equal(ensemble(self.traj['CC']), False)
 
     def test_allow_self_transitions_true(self):
         raise SkipTest

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -143,13 +143,19 @@ class testMSTISNetwork(object):
 class testTPSNetwork(object):
     def setup(self):
         from test_helpers import CallIdentity
-        xval = CallIdentity()
+        xval = paths.CV_Function("xval", lambda snap: snap.xyz[0][0])
         self.stateA = paths.CVRangeVolume(xval, float("-inf"), -0.5)
         self.stateB = paths.CVRangeVolume(xval, -0.1, 0.1)
         self.stateC = paths.CVRangeVolume(xval, 0.5, float("inf"))
         self.states = [self.stateA, self.stateB, self.stateC]
         self.traj = {}
-        self.traj['AA'] = make_1d_traj([-0.51, -0.49, -0.42])
+        self.traj['AA'] = make_1d_traj([-0.51, -0.49, -0.49, -0.52])
+        self.traj['AB'] = make_1d_traj([-0.51, -0.25, -0.25, 0.0])
+        self.traj['BA'] = make_1d_traj([0.0, -0.15, -0.35, -0.52])
+        self.traj['BB'] = make_1d_traj([0.0, -0.25, 0.25, 0.02])
+        self.traj['BC'] = make_1d_traj([0.01, 0.16, 0.25, 0.53])
+        self.traj['CC'] = make_1d_traj([0.51, 0.35, 0.36, 0.55])
+        self.traj['CA'] = make_1d_traj([0.52, 0.22, -0.22, -0.52])
         
     # define all the test networks as properties: we can do something
     # similar then for the fixed path length, and just need to override
@@ -238,9 +244,23 @@ class testTPSNetwork(object):
             os.remove(fname)
 
     def test_allow_self_transitions_false(self):
-        raise SkipTest
+        network = TPSNetwork.from_states_all_to_all(
+            self.states, allow_self_transitions=False
+        )
+        assert_equal(len(network.sampling_ensembles), 1)
+        ensemble = network.sampling_ensembles[0]
+        assert_equal(ensemble(self.traj['AA']), False)
+        assert_equal(ensemble(self.traj['AB']), True)
+        assert_equal(ensemble(self.traj['BA']), True)
+        assert_equal(ensemble(self.traj['BC']), True)
+        assert_equal(ensemble(self.traj['CA']), True)
+        assert_equal(ensemble(self.traj['BB']), False)
+        assert_equal(ensemble(self.traj['CC']), False)
 
     def test_allow_self_transitions_true(self):
+        network = TPSNetwork.from_states_all_to_all(
+            self.states, allow_self_transitions=True
+        )
         raise SkipTest
 
 class testFixedLengthTPSNetwork(testTPSNetwork):

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -261,7 +261,15 @@ class testTPSNetwork(object):
         network = TPSNetwork.from_states_all_to_all(
             self.states, allow_self_transitions=True
         )
-        raise SkipTest
+        assert_equal(len(network.sampling_ensembles), 1)
+        ensemble = network.sampling_ensembles[0]
+        assert_equal(ensemble(self.traj['AA']), True)
+        assert_equal(ensemble(self.traj['AB']), True)
+        assert_equal(ensemble(self.traj['BA']), True)
+        assert_equal(ensemble(self.traj['BC']), True)
+        assert_equal(ensemble(self.traj['CA']), True)
+        assert_equal(ensemble(self.traj['BB']), True)
+        assert_equal(ensemble(self.traj['CC']), True)
 
 class testFixedLengthTPSNetwork(testTPSNetwork):
     @property
@@ -324,5 +332,16 @@ class testFixedLengthTPSNetwork(testTPSNetwork):
         assert_equal(ensemble(self.traj['CC']), False)
 
     def test_allow_self_transitions_true(self):
-        raise SkipTest
+        network = FixedLengthTPSNetwork.from_states_all_to_all(
+            self.states, allow_self_transitions=True, length=4
+        )
+        assert_equal(len(network.sampling_ensembles), 1)
+        ensemble = network.sampling_ensembles[0]
+        assert_equal(ensemble(self.traj['AA']), True)
+        assert_equal(ensemble(self.traj['AB']), True)
+        assert_equal(ensemble(self.traj['BA']), True)
+        assert_equal(ensemble(self.traj['BC']), True)
+        assert_equal(ensemble(self.traj['CA']), True)
+        assert_equal(ensemble(self.traj['BB']), True)
+        assert_equal(ensemble(self.traj['CC']), True)
 

--- a/openpathsampling/tests/testnetwork.py
+++ b/openpathsampling/tests/testnetwork.py
@@ -148,6 +148,8 @@ class testTPSNetwork(object):
         self.stateB = paths.CVRangeVolume(xval, -0.1, 0.1)
         self.stateC = paths.CVRangeVolume(xval, 0.5, float("inf"))
         self.states = [self.stateA, self.stateB, self.stateC]
+        self.traj = {}
+        self.traj['AA'] = make_1d_traj([-0.51, -0.49, -0.42])
         
     # define all the test networks as properties: we can do something
     # similar then for the fixed path length, and just need to override
@@ -235,6 +237,12 @@ class testTPSNetwork(object):
         if os.path.isfile(fname):
             os.remove(fname)
 
+    def test_allow_self_transitions_false(self):
+        raise SkipTest
+
+    def test_allow_self_transitions_true(self):
+        raise SkipTest
+
 class testFixedLengthTPSNetwork(testTPSNetwork):
     @property
     def network2a(self):
@@ -280,3 +288,10 @@ class testFixedLengthTPSNetwork(testTPSNetwork):
                         self.network3a, self.network3b, self.network3c]:
             assert_equal(network.sampling_transitions[0].length, 10)
             assert_equal(network.transitions.values()[0].length, 10)
+
+    def test_allow_self_transitions_false(self):
+        raise SkipTest
+
+    def test_allow_self_transitions_true(self):
+        raise SkipTest
+


### PR DESCRIPTION
Right now, if we create a `TPSNetwork` with `from_states_all_to_all`, we get literally *all* the possible transitions, including A->A. Typically, we don’t want the self-transitions to be allowed.

This PR adds an `allow_self_transitions` flag to the creation of `TPSNetwork` and `FixedLengthTPSNetwork`. This flag will default to `False`, in which case there are no A->A transitions.

This makes a rather significant change in the way MSTPS is handled internally: instead of saying that there is only one sequential ensemble to check (leave any state; go to any state), now it is the union of a sequential ensemble for every state (leave that state; go to any other state). This will have some negative effects on speed, especially when building the trajectory backwards. We'll see scaling something like $O(t * N_S)$, where $t$ is the length of the trajectory and $N_S$ is the number of states.

However, this is important in order to have multiple state TPS work correctly.

- [x] Add `allow_self_transitions`
- [x] Tests for `allow_self_transitions=True`
- [x] Tests for `allow_self_transitions=False`
- [x] Update docstrings