### PR TITLE
Add `file_size` and `file_size_str` to netcdfplus

### DIFF
--- a/openpathsampling/netcdfplus/netcdfplus.py
+++ b/openpathsampling/netcdfplus/netcdfplus.py
@@ -298,6 +298,20 @@ class NetCDFPlus(netCDF4.Dataset):
 
         self.sync()
 
+
+    @property
+    def file_size(self):
+        return os.path.getsize(self.filename)
+
+    @property
+    def file_size_str(self):
+        current = float(self.file_size)
+        for prefix in ["k", "M", "G"]:
+            if current > 1024:
+                output_prefix = prefix
+                current /= 1024.0
+        return "{0:.2f}{1}B".format(current, prefix)
+
     def _setup_class(self):
         """
         Sets the basic properties for the storage


### PR DESCRIPTION
This just gives a shortcut to obtain the size of a file associated with a netcdfplus storage. It also gives a property with string output to convert that to a human-readable number in kB, MB, or GB (technically kiB, MiB, or GiB).

This is useful when doing analysis in an ipynb -- it is nice to get an overview of how big the file is before running analysis that might take a while.

Should be ready to merge immediately on passing tests.