### PR TITLE
Fix bug in move scheme frequency calculation

### DIFF
--- a/openpathsampling/analysis/move_scheme.py
+++ b/openpathsampling/analysis/move_scheme.py
@@ -718,7 +718,10 @@ class MoveScheme(StorableNamedObject):
         if self._mover_acceptance == { }:
             self.move_acceptance(storage)
 
-        tot_trials = len(storage.steps)
+        n_no_move_trials = sum([self._mover_acceptance[k][1]
+                                for k in self._mover_acceptance.keys()
+                                if k[0] is None])
+        tot_trials = len(storage.steps) - n_no_move_trials
         for groupname in my_movers.keys():
             group = my_movers[groupname]
             for mover in group:


### PR DESCRIPTION
Fixes problem that move schemes included the EmptyMove (used to set initial conditions) when calculating the frequency at which a move was actually used. This gave $N/(N+1)$ for $N$ moves when only one move was possible: so instead of the only move possible being run 100/100 = 100% of the time, it was run 100/101 = 99.01% of the time (gradually getter closer to 100% with more trials, but still, looks like nonsense)

Ready to merge as soon as it passes tests.